### PR TITLE
Fix integer parsing in arithmetic expressions

### DIFF
--- a/parser/src/main/java/com/nedap/archie/adlparser/treewalkers/AssertionsParser.java
+++ b/parser/src/main/java/com/nedap/archie/adlparser/treewalkers/AssertionsParser.java
@@ -120,7 +120,7 @@ public class AssertionsParser extends BaseTreeWalker {
 
     private Expression parseArithmeticLeaf(Arithmetic_leafContext context) {
         if(context.integer_value() != null) {
-            return new Constant<>(ExpressionType.INTEGER, Integer.parseInt(context.real_value().getText()));
+            return new Constant<>(ExpressionType.INTEGER, Integer.parseInt(context.integer_value().getText()));
         }
         if(context.real_value() != null) {
             return new Constant<>(ExpressionType.REAL, Double.parseDouble(context.real_value().getText()));


### PR DESCRIPTION
Changed from real_value() to integer_value()