### PR TITLE
Refactor typename lookup

### DIFF
--- a/archetypemodel/src/main/java/com/nedap/archie/aom/CPrimitiveObject.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/CPrimitiveObject.java
@@ -2,6 +2,7 @@ package com.nedap.archie.aom;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Primitive object. Parameterized with a Constraint type and AssumedAndDefault value type, to be able to override
@@ -54,5 +55,26 @@ public class CPrimitiveObject<Constraint, AssumedAndDefaultValue> extends CDefin
             throw new UnsupportedOperationException("Cannot set node id on a CPrimitiveObject");
         }
     }
+
+    /**
+     * True if the given value is a valid value for this constraint
+     * Must be overridden in classes where the AssumedAndDefaultValue is not the actual value.
+     * For example when it is an interval or pattern
+     *
+     * @param value
+     * @return
+     */
+    public boolean isValidValue(AssumedAndDefaultValue value) {
+        if(getConstraint().isEmpty()) {
+            return true;
+        }
+        for(Constraint constraint:getConstraint()) {
+            if(Objects.equals(constraint, value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }
 

--- a/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/COrdered.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/COrdered.java
@@ -4,8 +4,23 @@ import com.nedap.archie.aom.CDefinedObject;
 import com.nedap.archie.aom.CPrimitiveObject;
 import com.nedap.archie.base.Interval;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 15/10/15.
  */
 public class COrdered<T> extends CPrimitiveObject<Interval<T>, T> {
+
+    @Override
+    public boolean isValidValue(T value) {
+        if(getConstraint().isEmpty()) {
+            return true;
+        }
+        for(Interval<T> constraint:getConstraint()) {
+            if(constraint.has(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CString.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CString.java
@@ -23,7 +23,7 @@ public class CString extends CPrimitiveObject<String, String> {
                 //regexp. Strip first and last character and match. If you want to input
                 //data starting and ending with '/', you cannot in the AOM, although ADL lets you express if just fine.
                 //perhaps we should make the constraint object something more expressive than a String?
-                if(value.matches(constraint.substring(1).substring(0, constraint.length()-1))) {
+                if(value.matches(constraint.substring(1).substring(0, constraint.length()-2))) {
                     return true;
                 }
             } else {

--- a/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CString.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CString.java
@@ -28,7 +28,9 @@ public class CString extends CPrimitiveObject<String, String> {
                 }
             } else {
                 //TODO: does case matter here?
-                return Objects.equals(value, constraint);
+                if(Objects.equals(value, constraint)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CString.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CString.java
@@ -3,8 +3,34 @@ package com.nedap.archie.aom.primitives;
 import com.nedap.archie.aom.CDefinedObject;
 import com.nedap.archie.aom.CPrimitiveObject;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
 /**
  * Created by pieter.bos on 15/10/15.
  */
 public class CString extends CPrimitiveObject<String, String> {
+
+    public boolean isValidValue(String value) {
+        if(getConstraint().isEmpty()) {
+            return true;
+        }
+        for(String constraint:getConstraint()) {
+            if(constraint.length() > 1 &&
+                    ((constraint.startsWith("/") && constraint.endsWith("/")) ||
+                            (constraint.startsWith("^") && constraint.endsWith("^")))) {
+                //regexp. Strip first and last character and match. If you want to input
+                //data starting and ending with '/', you cannot in the AOM, although ADL lets you express if just fine.
+                //perhaps we should make the constraint object something more expressive than a String?
+                if(value.matches(constraint.substring(1).substring(0, constraint.length()-1))) {
+                    return true;
+                }
+            } else {
+                //TODO: does case matter here?
+                return Objects.equals(value, constraint);
+            }
+        }
+        return false;
+    }
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CTemporal.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CTemporal.java
@@ -16,4 +16,16 @@ public  class CTemporal<T> extends COrdered<T>{
     public void setPatternedConstraint(String patternedConstraint) {
         this.patternedConstraint = patternedConstraint;
     }
+
+    public boolean isValidValue(T value) {
+        if(getConstraint().isEmpty() && patternedConstraint == null) {
+            return true;
+        }
+        if(patternedConstraint == null) {
+            return super.isValidValue(value);
+        } else {
+            //TODO: find a library that validates ISO 8601 patterns
+            return true;
+        }
+    }
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -24,12 +24,12 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
             return true;
         }
         for(String constraint:getConstraint()) {
-            if(constraint.startsWith("ac")) {
+            if(constraint.startsWith("at")) {
                 if(value.getCodeString() != null && value.getCodeString().equals(constraint)) {
                     return true;
                 }
-            } else if (constraint.startsWith("at")) {
-                if(value.getTerminologyId() != null && value.getTerminologyId().equals(constraint)) {
+            } else if (constraint.startsWith("ac")) {
+                if(value.getTerminologyId() != null && value.getTerminologyId().getValue().equals(constraint)) {
                     return true;
                 }
             }

--- a/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -2,11 +2,39 @@ package com.nedap.archie.aom.primitives;
 
 import com.nedap.archie.aom.CPrimitiveObject;
 import com.nedap.archie.base.terminology.TerminologyCode;
+import com.nedap.archie.rm.datatypes.CodePhrase;
 
 /**
  *
  * Created by pieter.bos on 15/10/15.
  */
 public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> {
+
+    public boolean isValidValue(TerminologyCode value) {
+        return isValidValueCodePhrase(value);
+    }
+
+    public boolean isValidValue(CodePhrase value) {
+        return isValidValueCodePhrase(value);
+    }
+
+
+    private boolean isValidValueCodePhrase(CodePhrase value) {
+        if(getConstraint().isEmpty()) {
+            return true;
+        }
+        for(String constraint:getConstraint()) {
+            if(constraint.startsWith("ac")) {
+                if(value.getCodeString() != null && value.getCodeString().equals(constraint)) {
+                    return true;
+                }
+            } else if (constraint.startsWith("at")) {
+                if(value.getTerminologyId() != null && value.getTerminologyId().equals(constraint)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CTime.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/aom/primitives/CTime.java
@@ -6,4 +6,5 @@ import java.time.LocalTime;
  * Created by pieter.bos on 15/10/15.
  */
 public class CTime extends CTemporal<LocalTime> {
+
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/base/Interval.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/base/Interval.java
@@ -35,13 +35,13 @@ public class Interval<T> {
         this.upperIncluded = upperIncluded;
     }
 
-    public static <T>  Interval lowerUnbounded(T upper, boolean upperIncluded) {
+    public static <T extends Comparable>  Interval lowerUnbounded(T upper, boolean upperIncluded) {
         Interval<T> result = new Interval<>(null, upper, true, upperIncluded);
         result.setLowerUnbounded(true);
         return result;
     }
 
-    public static <T>  Interval upperUnbounded(T lower, boolean lowerIncluded) {
+    public static <T extends Comparable>  Interval upperUnbounded(T lower, boolean lowerIncluded) {
         Interval<T> result = new Interval<>(lower, null, lowerIncluded, true);
         result.setUpperUnbounded(true);
         return result;
@@ -93,6 +93,40 @@ public class Interval<T> {
 
     public void setUpperIncluded(boolean upperIncluded) {
         this.upperIncluded = upperIncluded;
+    }
+
+    public boolean has(T value) {
+        //since TemporalAmount does not implement Comparable we have to do some magic here
+        if(!(isComparable(lower) && isComparable(upper) && isComparable(value))) {
+            throw new UnsupportedOperationException("subclasses of interval not implementing comparable should implement their own has method");
+        }
+        Comparable comparableValue = (Comparable) value;
+        Comparable comparableLower = (Comparable) lower;
+        Comparable comparableUpper = (Comparable) upper;
+
+        if(value == null) {
+            //interval values are not concerned with cardinality, so return true if not set
+            return true;
+        }
+
+        if(!lowerUnbounded) {
+            int comparedWithLower = comparableValue.compareTo(comparableLower);
+            if (comparedWithLower < 0 || (!lowerIncluded && comparedWithLower == 0)) {
+                return false;
+            }
+        }
+
+        if(!upperUnbounded) {
+            int comparedWithUpper = comparableValue.compareTo(comparableUpper);
+            if (comparedWithUpper > 0 || (!upperIncluded && comparedWithUpper == 0)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isComparable(T upper) {
+        return upper == null || upper instanceof Comparable;
     }
 
     @Override

--- a/archetypemodel/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
@@ -55,4 +55,10 @@ public class TerminologyCode extends CodePhrase {
         TerminologyId terminologyId = getTerminologyId();
         return terminologyId == null ? null : terminologyId.getValue();
     }
+
+    public String toString() {
+        return terminologyVersion == null ?
+                "[" + getTerminologyId() + "::" + getCodeString() + "]" :
+                "[" + getTerminologyId() + "(" + terminologyVersion + ")::" + getCodeString() + "]";
+    }
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
@@ -1,6 +1,8 @@
 package com.nedap.archie.base.terminology;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.nedap.archie.rm.datatypes.CodePhrase;
+import com.nedap.archie.rm.datatypes.TerminologyId;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -8,12 +10,11 @@ import java.util.regex.Pattern;
 /**
  * Created by pieter.bos on 15/10/15.
  */
-public class TerminologyCode {
-    private String terminologyId;
+public class TerminologyCode extends CodePhrase {
     private String terminologyVersion;
-    private String codeString;
 
     public TerminologyCode() {
+        super();
     }
 
     @JsonCreator
@@ -26,22 +27,20 @@ public class TerminologyCode {
         Matcher matcher = pattern.matcher(terminologyString);
         TerminologyCode result = new TerminologyCode();
         if(matcher.matches()) {
-            result.terminologyId = matcher.group("terminologyId");
-            result.codeString = matcher.group("codeString");
-            result.terminologyVersion = matcher.group("terminologyVersion");
+            result.setTerminologyId(matcher.group("terminologyId"));
+            result.setCodeString(matcher.group("codeString"));
+            result.setTerminologyVersion(matcher.group("terminologyVersion"));
 
         } else {
-            result.codeString = terminologyString;
+            result.setCodeString(terminologyString);
         }
         return result;
     }
 
-    public String getTerminologyId() {
-        return terminologyId;
-    }
-
-    public void setTerminologyId(String terminologyId) {
-        this.terminologyId = terminologyId;
+    public void setTerminologyId(String terminologyIdString) {
+        TerminologyId terminologyId = new TerminologyId();
+        terminologyId.setValue(terminologyIdString);
+        setTerminologyId(terminologyId);
     }
 
     public String getTerminologyVersion() {
@@ -52,11 +51,8 @@ public class TerminologyCode {
         this.terminologyVersion = terminologyVersion;
     }
 
-    public String getCodeString() {
-        return codeString;
-    }
-
-    public void setCodeString(String codeString) {
-        this.codeString = codeString;
+    public String getTerminologyIdString() {
+        TerminologyId terminologyId = getTerminologyId();
+        return terminologyId == null ? null : terminologyId.getValue();
     }
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/query/APathQuery.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/query/APathQuery.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.query;
 
 
+import com.nedap.archie.aom.CObject;
 import com.nedap.archie.rm.archetypes.Locatable;
 import com.nedap.archie.rm.archetypes.Pathable;
 import com.nedap.archie.util.NamingUtil;
@@ -108,7 +109,7 @@ public class APathQuery {
     }
 
     //TODO: get diagnostic information about where the finder stopped in the path - could be very useful!
-    public <T> T find(Pathable root) {
+    public <T> T find(Object root) {
         //TODO: you can access undesired methods like the getClass().getClassLoader() methods with these queries
         //find a way to whitelist the resulting classes? Or switch to field-based queries?
 

--- a/archetypemodel/src/main/java/com/nedap/archie/query/APathQuery.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/query/APathQuery.java
@@ -148,10 +148,15 @@ public class APathQuery {
                             throw new IllegalArgumentException("cannot handle RM-queries with node names or archetype references yet");
                         }
                     }
-                } else {
-                    if(segment.getNodeId() != null) {
-                        throw new IllegalArgumentException("node id specified in path, but object is not a Locatable: " + currentObject);
+                } else if (segment.hasNumberIndex()) {
+                    int number = Integer.parseInt(segment.getNodeId());
+                    if(number != 1) {
+                        return null;
                     }
+                } else {
+                    //not a locatable, but that's fine
+                    //in openehr, in archetypes everythign has node ids. Datavalues do not in the rm. a bit ugly if you ask
+                    //me, but that's why there's no 'if there's a nodeId set, this won't match!' code here.
                 }
             }
             return (T) currentObject;

--- a/archetypemodel/src/main/java/com/nedap/archie/rm/archetypes/Archetyped.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/rm/archetypes/Archetyped.java
@@ -13,4 +13,29 @@ public class Archetyped {
     @Nullable
     private ArchetypeHRID templateId; //not sure if this is still required in AOM/ADL 2
     private String rmVersion;
+
+    public ArchetypeHRID getArchetypeId() {
+        return archetypeId;
+    }
+
+    public void setArchetypeId(ArchetypeHRID archetypeId) {
+        this.archetypeId = archetypeId;
+    }
+
+    @Nullable
+    public ArchetypeHRID getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(@Nullable ArchetypeHRID templateId) {
+        this.templateId = templateId;
+    }
+
+    public String getRmVersion() {
+        return rmVersion;
+    }
+
+    public void setRmVersion(String rmVersion) {
+        this.rmVersion = rmVersion;
+    }
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/rm/datastructures/IntervalEvent.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/rm/datastructures/IntervalEvent.java
@@ -13,7 +13,7 @@ public class IntervalEvent<Type extends ItemStructure> extends Event<Type> {
 
     private DvDuration width;
     @Nullable
-    private Integer sampleCount;
+    private Long sampleCount;
     private DvCodedText mathFunction;
 
     public DvDuration getWidth() {
@@ -25,11 +25,11 @@ public class IntervalEvent<Type extends ItemStructure> extends Event<Type> {
     }
 
     @Nullable
-    public Integer getSampleCount() {
+    public Long getSampleCount() {
         return sampleCount;
     }
 
-    public void setSampleCount(@Nullable Integer sampleCount) {
+    public void setSampleCount(@Nullable Long sampleCount) {
         this.sampleCount = sampleCount;
     }
 

--- a/archetypemodel/src/main/java/com/nedap/archie/rm/datatypes/TerminologyId.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/rm/datatypes/TerminologyId.java
@@ -21,4 +21,8 @@ public class TerminologyId {
     public void setValue(String value) {
         this.value = value;
     }
+
+    public String toString() {
+        return value;
+    }
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/DvBoolean.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/DvBoolean.java
@@ -7,10 +7,12 @@ public class DvBoolean extends DataValue implements SingleValuedDataValue<Boolea
 
     private Boolean value;
 
+    @Override
     public Boolean getValue() {
         return value;
     }
 
+    @Override
     public void setValue(Boolean value) {
         this.value = value;
     }

--- a/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/TermMapping.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/TermMapping.java
@@ -14,7 +14,7 @@ public class TermMapping {
      * < = narrower term
      * = = equals term
      * > = broader term
-     * ? = no clue
+     * ? = the kind of mapping is unknown
      */
     private char match = '?';
     @Nullable

--- a/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvCount.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvCount.java
@@ -3,5 +3,5 @@ package com.nedap.archie.rm.datavalues.quantity;
 /**
  * Created by pieter.bos on 04/11/15.
  */
-public class DvCount extends DvAmount<Integer> {
+public class DvCount extends DvAmount<Long> {
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvOrdered.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvOrdered.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rm.datavalues.quantity;
 
 import com.nedap.archie.rm.datatypes.CodePhrase;
+import com.nedap.archie.rm.datavalues.DataValue;
 
 
 import javax.annotation.Nullable;
@@ -10,7 +11,7 @@ import java.util.List;
 /**
  * Created by pieter.bos on 04/11/15.
  */
-public abstract class DvOrdered<ComparableType> implements Comparable<ComparableType> {
+public abstract class DvOrdered<ComparableType> extends DataValue implements Comparable<ComparableType> {
 
     @Nullable
     private CodePhrase normalStatus;

--- a/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantity.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantity.java
@@ -27,4 +27,5 @@ public class DvQuantity extends DvAmount<Double> {
     public void setUnits(String units) {
         this.units = units;
     }
+
 }

--- a/archetypemodel/src/main/java/com/nedap/archie/util/NamingUtil.java
+++ b/archetypemodel/src/main/java/com/nedap/archie/util/NamingUtil.java
@@ -32,4 +32,8 @@ public class NamingUtil {
     public static String attributeNameToGetMethod(String snakeCased) {
         return "get" + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, snakeCased);
     }
+
+    public static String attributeNameToSetMethod(String snakeCased) {
+        return "set" + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, snakeCased);
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ subprojects {
 		compile 'org.slf4j:slf4j-api:1.7.12'
         compile 'com.fasterxml.jackson.core:jackson-annotations:2.6.3'
 		compile 'com.guestful.module:guestful.module.jsr310-extensions:1.4' //kryo java.time serializers
-
+		compile 'commons-beanutils:commons-beanutils:1.9.2'
 		compile 'com.google.guava:guava:19.0-rc2'
 
 		compile 'org.checkerframework:checker:1.9.7'

--- a/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/ConstraintToClassLookup.java
+++ b/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/ConstraintToClassLookup.java
@@ -1,0 +1,88 @@
+package com.nedap.archie.adlparser.modelconstraints;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.nedap.archie.aom.CComplexObject;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.reflections.ReflectionUtils.getAllFields;
+
+/**
+ * Utility to find Reference Model classed based on the type names as used in the Archetype
+ *
+ * Created by pieter.bos on 02/02/16.
+ */
+public class ConstraintToClassLookup {
+
+    private String packageName;
+    private ClassLoader classLoader;
+
+    private Map<String, Class> rmTypeNamesToClasses = new HashMap<>();
+
+    //constructed as  a field to save some object creation
+    protected PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy lowerCaseWithUnderscoresStrategy = new PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy();
+
+    public ConstraintToClassLookup(String packageName) {
+        this(packageName, ReflectionConstraintImposer.class.getClassLoader());
+    }
+
+    public ConstraintToClassLookup(String packageName, ClassLoader classLoader) {
+        this.packageName = packageName;
+        this.classLoader = classLoader;
+
+        Reflections reflections = new Reflections(packageName, classLoader, new SubTypesScanner(false));
+
+        Set<String> types = reflections.getAllTypes();
+        for(String type:types) {
+            try {
+                Class clazz = classLoader.loadClass(type);
+                String rmTypeName = getRmTypeName(clazz);
+                rmTypeNamesToClasses.put(rmTypeName, clazz);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    public Class getClass(String rmTypename) {
+        return rmTypeNamesToClasses.get(rmTypename);
+    }
+
+    public  Map<String, Class> getRmTypeNameToClassMap() {
+        return rmTypeNamesToClasses;
+    }
+
+    /**
+     * Naming from fields. Override to get custom behaviour
+     * @param field
+     * @return
+     */
+    public String getRmAttributeName(Field field) {
+        return lowerCaseWithUnderscoresStrategy.translate(field.getName());
+    }
+
+    public Field getField(Class clazz, String attributeName) {
+        Set<Field> allFields = getAllFields(clazz);
+        for(Field field:allFields) {
+            if(attributeName.equals(getRmAttributeName(field))) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+
+    /**
+     * Naming from classes. Override to get custom behaviour
+     * @param clazz
+     * @return
+     */
+    public String getRmTypeName(Class clazz) {
+        return lowerCaseWithUnderscoresStrategy.translate(clazz.getSimpleName()).toUpperCase();
+    }
+}

--- a/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/RMConstraintImposer.java
+++ b/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/RMConstraintImposer.java
@@ -6,23 +6,9 @@ package com.nedap.archie.adlparser.modelconstraints;
  * Created by pieter.bos on 04/11/15.
  */
 public class RMConstraintImposer extends ReflectionConstraintImposer {
+
     public RMConstraintImposer() {
-        super("com.nedap.archie.rm");
+        super(new RMConstraintToClassLookup());
     }
 
-    protected String getRmTypeName(Class clazz) {
-        String name = clazz.getSimpleName();
-        switch(clazz.getSimpleName()) {
-            //some overrides to get every name right. The DV_URI is not really required i think, just to be sure
-            case "DvURI":
-                return "DV_URI";
-            case "DvEHRURI":
-                return "DV_EHR_URI";
-            case "UIDBasedId":
-                return "UID_BASED_ID";
-            default:
-
-        }
-        return super.getRmTypeName(clazz);
-    }
 }

--- a/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/RMConstraintToClassLookup.java
+++ b/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/RMConstraintToClassLookup.java
@@ -1,0 +1,28 @@
+package com.nedap.archie.adlparser.modelconstraints;
+
+/**
+ * Created by pieter.bos on 02/02/16.
+ */
+public class RMConstraintToClassLookup extends ConstraintToClassLookup {
+
+    public RMConstraintToClassLookup() {
+        super("com.nedap.archie.rm");
+    }
+
+    @Override
+    public String getRmTypeName(Class clazz) {
+        String name = clazz.getSimpleName();
+        switch(name) {
+            //some overrides to get every name right. The DV_URI is not really required i think, just to be sure
+            case "DvURI":
+                return "DV_URI";
+            case "DvEHRURI":
+                return "DV_EHR_URI";
+            case "UIDBasedId":
+                return "UID_BASED_ID";
+            default:
+
+        }
+        return super.getRmTypeName(clazz);
+    }
+}

--- a/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/RMObjectCreator.java
+++ b/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/RMObjectCreator.java
@@ -2,6 +2,7 @@ package com.nedap.archie.adlparser.modelconstraints;
 
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.rm.archetypes.Locatable;
+import com.nedap.archie.util.NamingUtil;
 import org.apache.commons.beanutils.BeanUtils;
 
 import java.lang.reflect.Field;
@@ -40,6 +41,9 @@ public class RMObjectCreator {
     public void set(Object object, String rmAttributeName, List<Object> values) {
         try {
             Field field = classLookup.getField(object.getClass(), rmAttributeName);
+            if(field == null) {
+                throw new IllegalArgumentException(String.format("Attribute %s not known for object %s", rmAttributeName, object.getClass().getSimpleName()));
+            }
             if(Collection.class.isAssignableFrom(field.getType())) {
                 Collection collection = (Collection) newInstance(field);
                 setField(object, field, collection);

--- a/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/RMObjectCreator.java
+++ b/parser/src/main/java/com/nedap/archie/adlparser/modelconstraints/RMObjectCreator.java
@@ -1,0 +1,100 @@
+package com.nedap.archie.adlparser.modelconstraints;
+
+import com.nedap.archie.aom.CObject;
+import com.nedap.archie.rm.archetypes.Locatable;
+import org.apache.commons.beanutils.BeanUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Created by pieter.bos on 03/02/16.
+ */
+public class RMObjectCreator {
+
+    private final ConstraintToClassLookup classLookup;
+
+    public RMObjectCreator(ConstraintToClassLookup lookup) {
+        this.classLookup = lookup;
+    }
+
+    public Object create(CObject constraint) {
+        Class clazz = classLookup.getClass(constraint.getRmTypeName());
+        try {
+            Object result = clazz.newInstance();
+            if(result instanceof Locatable) { //and most often, it will be
+                Locatable locatable = (Locatable) result;
+                locatable.setArchetypeNodeId(constraint.getNodeId());
+            }
+            return result;
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void set(Object object, String rmAttributeName, List<Object> values) {
+        try {
+            Field field = classLookup.getField(object.getClass(), rmAttributeName);
+            if(Collection.class.isAssignableFrom(field.getType())) {
+                Collection collection = (Collection) newInstance(field);
+                setField(object, field, collection);
+                if(values != null) {
+                    collection.addAll(values);
+                }
+            } else {
+                if(values == null || values.isEmpty()) {
+                    setField(object, field, null);
+                } else if(values.size() > 1) {
+                    throw new IllegalArgumentException(String.format("trying to set multiple values for a single valued field, %s %s",
+                                    object.getClass().getSimpleName(), rmAttributeName)
+                    );
+                } else {
+                    setField(object, field, values.get(0));
+                }
+            }
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private Object newInstance(Field field) throws InstantiationException, IllegalAccessException {
+        if(field.getType().equals(List.class)) {
+            return new ArrayList<>();
+        } else if (field.getType().equals(Set.class)) {
+            return new LinkedHashSet<>();
+        } else {
+            return field.getType().newInstance();
+        }
+    }
+
+    private void setField(Object object, Field field, Object value) throws InvocationTargetException, IllegalAccessException {
+        BeanUtils.setProperty(object, field.getName(), value);
+
+    }
+
+    public void addElementToList(Object object, String rmAttributeName, Object element) {
+        try {
+            Field field = classLookup.getField(object.getClass(), rmAttributeName);
+            Object collectionValue = field.get(object);
+
+            if(Collection.class.isAssignableFrom(field.getType())) {
+                if(collectionValue == null) {
+                    collectionValue = newInstance(field);
+                    setField(object, field, collectionValue);
+                }
+                Collection collection = (Collection) collectionValue;
+                collection.add(element);//TODO: use add method in object instead!
+            } else {
+                throw new IllegalArgumentException("trying to add an element to an object with type " + field.getType());
+            }
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/parser/src/main/java/com/nedap/archie/adlparser/treewalkers/PrimitivesConstraintParser.java
+++ b/parser/src/main/java/com/nedap/archie/adlparser/treewalkers/PrimitivesConstraintParser.java
@@ -120,7 +120,7 @@ public class PrimitivesConstraintParser extends BaseTreeWalker {
             String assumedValueString = terminologyCodeContext.AT_CODE().getText();
             assumedValue.setCodeString(assumedValueString);
             result.setAssumedValue(assumedValue);
-            result.addConstraint(assumedValue.getTerminologyId());
+            result.addConstraint(assumedValue.getTerminologyIdString());
         } else {
             if(terminologyCodeContext.AC_CODE() != null) {
                 result.addConstraint(terminologyCodeContext.AC_CODE().getText());

--- a/parser/src/test/java/com/nedap/archie/adlparser/PrimitivesConstraintParserTest.java
+++ b/parser/src/test/java/com/nedap/archie/adlparser/PrimitivesConstraintParserTest.java
@@ -10,8 +10,8 @@ import org.junit.BeforeClass;
  */
 public abstract class PrimitivesConstraintParserTest {
 
-    ADLParser parser;
-    Archetype archetype;
+    protected ADLParser parser;
+    protected Archetype archetype;
 
     @Before
     public void setup() throws Exception {

--- a/parser/src/test/java/com/nedap/archie/aom/BooleanConstraintsTest.java
+++ b/parser/src/test/java/com/nedap/archie/aom/BooleanConstraintsTest.java
@@ -1,0 +1,42 @@
+package com.nedap.archie.aom;
+
+import com.nedap.archie.aom.primitives.CBoolean;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by pieter.bos on 23/02/16.
+ */
+public class BooleanConstraintsTest {
+
+    @Test
+    public void onlyFalse() {
+        CBoolean test = new CBoolean();
+        test.addConstraint(false);
+        assertTrue(test.isValidValue(false));
+        assertFalse(test.isValidValue(true));
+    }
+
+    @Test
+    public void onlyTrue() {
+        CBoolean test = new CBoolean();
+        test.addConstraint(true);
+        assertTrue(test.isValidValue(true));
+        assertFalse(test.isValidValue(false));
+    }
+
+    @Test
+    public void both() {
+        CBoolean test = new CBoolean();
+        test.addConstraint(true);
+        test.addConstraint(false);
+        assertTrue(test.isValidValue(true));
+        assertTrue(test.isValidValue(false));
+
+        CBoolean test2 = new CBoolean();
+        assertTrue(test2.isValidValue(true));
+        assertTrue(test2.isValidValue(false));
+    }
+}

--- a/parser/src/test/java/com/nedap/archie/aom/DateConstraintsTest.java
+++ b/parser/src/test/java/com/nedap/archie/aom/DateConstraintsTest.java
@@ -1,0 +1,41 @@
+package com.nedap.archie.aom;
+
+import com.nedap.archie.aom.primitives.CDate;
+import com.nedap.archie.base.Interval;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by pieter.bos on 23/02/16.
+ */
+public class DateConstraintsTest {
+
+    @Test
+    public void dateConstraints() {
+        CDate unconstrained = new CDate();
+        unconstrained.isValidValue(LocalDate.now());
+        unconstrained.isValidValue(LocalDate.of(1972, Month.JANUARY, 1));
+
+        CDate interval = new CDate();
+        interval.addConstraint(new Interval<>(LocalDate.of(2015, Month.JANUARY, 1), LocalDate.of(2015, Month.DECEMBER, 31)));
+        assertTrue(interval.isValidValue(LocalDate.of(2015, Month.JUNE, 1)));
+        assertTrue(interval.isValidValue(LocalDate.of(2015, Month.JANUARY, 1)));
+        assertTrue(interval.isValidValue(LocalDate.of(2015, Month.DECEMBER, 31)));
+        assertFalse(interval.isValidValue(LocalDate.of(2016, Month.JANUARY, 1)));
+        assertFalse(interval.isValidValue(LocalDate.of(2014, Month.DECEMBER, 31)));
+
+        CDate twoInterVals = new CDate();
+        twoInterVals.addConstraint(new Interval<>(LocalDate.of(2015, Month.JANUARY, 1), LocalDate.of(2015, Month.DECEMBER, 31)));
+        twoInterVals.addConstraint(new Interval<>(LocalDate.of(2013, Month.JANUARY, 1), LocalDate.of(2013, Month.DECEMBER, 31)));
+        assertTrue(twoInterVals.isValidValue(LocalDate.of(2015, Month.JUNE, 1)));
+        assertTrue(twoInterVals.isValidValue(LocalDate.of(2013, Month.JUNE, 1)));
+        assertFalse(twoInterVals.isValidValue(LocalDate.of(2014, Month.JUNE, 1)));
+    }
+
+    //TODO: date patterns. also the implementation :)
+}

--- a/parser/src/test/java/com/nedap/archie/aom/NumberConstraintsTest.java
+++ b/parser/src/test/java/com/nedap/archie/aom/NumberConstraintsTest.java
@@ -1,0 +1,150 @@
+package com.nedap.archie.aom;
+
+import com.nedap.archie.adlparser.PrimitivesConstraintParserTest;
+import com.nedap.archie.adlparser.TemporalConstraintParserTest;
+import com.nedap.archie.aom.primitives.CInteger;
+import com.nedap.archie.aom.primitives.CReal;
+import com.nedap.archie.base.Interval;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by pieter.bos on 01/11/15.
+ */
+public class NumberConstraintsTest {
+
+    @Test
+    public void integers() {
+        CInteger noConstraints = new CInteger();
+        for(long i = -100l;i < 100l;i++) {
+            assertTrue(noConstraints.isValidValue(i));
+        }
+
+        CInteger constantConstraint = new CInteger();
+        constantConstraint.addConstraint(new Interval<>(55l));
+        assertTrue(constantConstraint.isValidValue(55l));
+        assertFalse(constantConstraint.isValidValue(54l));
+        assertFalse(constantConstraint.isValidValue(56l));
+
+        CInteger constantConstraints = new CInteger();
+        constantConstraints.addConstraint(new Interval(10L));
+        constantConstraints.addConstraint(new Interval(20L));
+        constantConstraints.addConstraint(new Interval(30L));
+        assertTrue(constantConstraints.isValidValue(10l));
+        assertTrue(constantConstraints.isValidValue(20l));
+        assertTrue(constantConstraints.isValidValue(30l));
+        assertFalse(constantConstraints.isValidValue(19l));
+
+        CInteger rangeConstraint = new CInteger();
+        rangeConstraint.addConstraint(new Interval<>(0l, 100l));
+        assertTrue(rangeConstraint.isValidValue(0l));
+        assertTrue(rangeConstraint.isValidValue(100l));
+        assertFalse(rangeConstraint.isValidValue(101l));
+        assertFalse(rangeConstraint.isValidValue(-1l));
+
+        CInteger rangeLowerNotIncluded = new CInteger();
+        rangeLowerNotIncluded.addConstraint(new Interval(0l, 100l, false, true));
+        assertFalse(rangeLowerNotIncluded.isValidValue(0l));
+        assertTrue(rangeLowerNotIncluded.isValidValue(100l));
+        assertFalse(rangeLowerNotIncluded.isValidValue(101l));
+        assertFalse(rangeLowerNotIncluded.isValidValue(-1l));
+
+
+        CInteger rangeUpperNotIncluded = new CInteger();
+        rangeUpperNotIncluded.addConstraint(new Interval(0l, 100l, true, false));
+        assertTrue(rangeUpperNotIncluded.isValidValue(0l));
+        assertFalse(rangeUpperNotIncluded.isValidValue(100l));
+        assertFalse(rangeUpperNotIncluded.isValidValue(101l));
+        assertFalse(rangeUpperNotIncluded.isValidValue(-1l));
+
+        CInteger rangeUpperUnbounded = new CInteger();
+        rangeUpperUnbounded.addConstraint(Interval.upperUnbounded(10l, true));
+        assertTrue(rangeUpperUnbounded.isValidValue(1000000l));
+        assertTrue(rangeUpperUnbounded.isValidValue(10l));
+        assertFalse(rangeUpperUnbounded.isValidValue(9l));
+
+        CInteger rangeLowerUnbounded = new CInteger();
+        rangeLowerUnbounded.addConstraint(Interval.lowerUnbounded(10l, true));
+        assertFalse(rangeLowerUnbounded.isValidValue(1000000l));
+        assertTrue(rangeLowerUnbounded.isValidValue(10l));
+        assertTrue(rangeLowerUnbounded.isValidValue(-100000000l));
+
+    }
+
+
+    /*
+    real_attr1 matches {100.0}
+        real_attr2 matches {10.0, 20.0, 30.0}
+        real_attr3 matches {|0.0..100.0|}
+        real_attr4 matches {|>0.0..100.0|}
+        real_attr5 matches {|0.0..<100.0|}
+        real_attr6 matches {|>0.0..<100.0|}
+        real_attr7 matches {|>=10.0|}
+        real_attr8 matches {|<=10.0|}
+        real_attr9 matches {|>=10.0|}
+        real_attr10 matches {|<=10.0|}
+        real_attr11 matches {|-10.0..-5.0|}
+        real_attr12 matches {10.0}
+        real_attr13
+     */
+    @Test
+    public void reals() {
+
+        CReal noConstraints = new CReal();
+        for(double i = -100d;i < 100d;i++) {
+            assertTrue(noConstraints.isValidValue(i));
+        }
+
+        CReal constantConstraint = new CReal();
+        /* constant reals are very strange intervals, but let's test them nonetheless. Perhaps they should work with a delta?*/
+        constantConstraint.addConstraint(new Interval<>(55d));
+        assertTrue(constantConstraint.isValidValue(55d));
+        assertFalse(constantConstraint.isValidValue(55.01d));
+        assertFalse(constantConstraint.isValidValue(54.99d));
+
+        CReal constantConstraints = new CReal();
+        constantConstraints.addConstraint(new Interval(10d));
+        constantConstraints.addConstraint(new Interval(20d));
+        constantConstraints.addConstraint(new Interval(30d));
+        assertTrue(constantConstraints.isValidValue(10d));
+        assertTrue(constantConstraints.isValidValue(20d));
+        assertTrue(constantConstraints.isValidValue(30d));
+        assertFalse(constantConstraints.isValidValue(19.99d));
+
+
+        CReal rangeConstraint = new CReal();
+        rangeConstraint.addConstraint(new Interval<>(0d, 100d));
+        assertTrue(rangeConstraint.isValidValue(0d));
+        assertTrue(rangeConstraint.isValidValue(100d));
+        assertFalse(rangeConstraint.isValidValue(100.1d));
+        assertFalse(rangeConstraint.isValidValue(-1d));
+
+        CReal rangeLowerNotIncluded = new CReal();
+        rangeLowerNotIncluded.addConstraint(new Interval(0d, 100d, false, true));
+        assertFalse(rangeLowerNotIncluded.isValidValue(0d));
+        assertTrue(rangeLowerNotIncluded.isValidValue(100d));
+        assertFalse(rangeLowerNotIncluded.isValidValue(100.1d));
+        assertFalse(rangeLowerNotIncluded.isValidValue(-1d));
+
+
+        CReal rangeUpperNotIncluded = new CReal();
+        rangeUpperNotIncluded.addConstraint(new Interval(0d, 100d, true, false));
+        assertTrue(rangeUpperNotIncluded.isValidValue(0d));
+        assertFalse(rangeUpperNotIncluded.isValidValue(100d));
+        assertFalse(rangeUpperNotIncluded.isValidValue(101d));
+        assertFalse(rangeUpperNotIncluded.isValidValue(-1d));
+
+        CReal rangeUpperUnbounded = new CReal();
+        rangeUpperUnbounded.addConstraint(Interval.upperUnbounded(10d, true));
+        assertTrue(rangeUpperUnbounded.isValidValue(1000000d));
+        assertTrue(rangeUpperUnbounded.isValidValue(10d));
+        assertFalse(rangeUpperUnbounded.isValidValue(9d));
+
+        CReal rangeLowerUnbounded = new CReal();
+        rangeLowerUnbounded.addConstraint(Interval.lowerUnbounded(10d, true));
+        assertFalse(rangeLowerUnbounded.isValidValue(1000000d));
+        assertTrue(rangeLowerUnbounded.isValidValue(10d));
+        assertTrue(rangeLowerUnbounded.isValidValue(-100000000d));
+    }
+}

--- a/parser/src/test/java/com/nedap/archie/aom/StringConstraintsTest.java
+++ b/parser/src/test/java/com/nedap/archie/aom/StringConstraintsTest.java
@@ -1,0 +1,65 @@
+package com.nedap.archie.aom;
+
+import com.nedap.archie.aom.primitives.CString;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by pieter.bos on 23/02/16.
+ */
+public class StringConstraintsTest {
+
+    @Test
+    public void stringConstants() {
+        CString noConstraint = new CString();
+        assertTrue(noConstraint.isValidValue("a"));
+        assertTrue(noConstraint.isValidValue("b"));
+        assertTrue(noConstraint.isValidValue("The complete works of William Shakespeare"));
+
+        CString oneConstraint = new CString();
+        oneConstraint.addConstraint("very specific secret string");
+        assertTrue(oneConstraint.isValidValue("very specific secret string"));
+        assertFalse(oneConstraint.isValidValue("not specific at all not secret string"));
+
+
+        CString moreConstraints = new CString();
+        moreConstraints.addConstraint("very specific secret string");
+        moreConstraints.addConstraint("another string");
+        assertTrue(moreConstraints.isValidValue("very specific secret string"));
+        assertTrue(moreConstraints.isValidValue("another string"));
+        assertFalse(moreConstraints.isValidValue("not specific at all not secret string"));
+
+
+    }
+
+    @Test
+    public void stringRegexps() {
+
+        CString oneConstraint = new CString();
+        oneConstraint.addConstraint("/a+b*/");
+        assertTrue(oneConstraint.isValidValue("a"));
+        assertTrue(oneConstraint.isValidValue("aa"));
+        assertTrue(oneConstraint.isValidValue("aaaaaaaabbbbb"));
+        assertFalse(oneConstraint.isValidValue("aaaaaaaabbbbbc"));
+
+        CString moreConstraints = new CString();
+        moreConstraints.addConstraint("/a+b*/");
+        moreConstraints.addConstraint("^dbca+^");
+        assertTrue(moreConstraints.isValidValue("ab"));
+        assertTrue(moreConstraints.isValidValue("aabb"));
+        assertTrue(moreConstraints.isValidValue("dbcaa"));
+        assertFalse(moreConstraints.isValidValue("Something else"));
+
+        CString mixedConstraints = new CString();
+        mixedConstraints.addConstraint("/a+b*/");
+        mixedConstraints.addConstraint("^dbca+^");
+        mixedConstraints.addConstraint("Something else");
+        assertTrue(mixedConstraints.isValidValue("ab"));
+        assertTrue(mixedConstraints.isValidValue("aabb"));
+        assertTrue(mixedConstraints.isValidValue("dbcaa"));
+        assertTrue(mixedConstraints.isValidValue("Something else"));
+        assertFalse(mixedConstraints.isValidValue("what more?"));
+    }
+}

--- a/parser/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
+++ b/parser/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
@@ -1,0 +1,38 @@
+package com.nedap.archie.aom;
+
+import com.nedap.archie.aom.primitives.CTerminologyCode;
+import com.nedap.archie.base.terminology.TerminologyCode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by pieter.bos on 23/02/16.
+ */
+public class TerminologyCodeConstraintsTest {
+
+    @Test
+    public void noConstraint() {
+        CTerminologyCode code = new CTerminologyCode();
+        assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac12::at23]")));
+    }
+
+    @Test
+    public void terminologyIdConstraint() {
+        CTerminologyCode code = new CTerminologyCode();
+        code.addConstraint("ac12");
+        assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac12::at23]")));
+        assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac12::at24]")));
+        assertFalse(code.isValidValue(TerminologyCode.createFromString("[ac13::at23]")));
+    }
+
+    @Test
+    public void terminologyCodeConstraint() {
+        CTerminologyCode code = new CTerminologyCode();
+        code.addConstraint("at23");
+        assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac12::at23]")));
+        assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac13::at23]")));
+        assertFalse(code.isValidValue(TerminologyCode.createFromString("[ac13::at24]")));
+    }
+}

--- a/parser/src/test/java/com/nedap/archie/aom/TimeConstraintsTest.java
+++ b/parser/src/test/java/com/nedap/archie/aom/TimeConstraintsTest.java
@@ -1,0 +1,43 @@
+package com.nedap.archie.aom;
+
+import com.nedap.archie.aom.primitives.CDate;
+import com.nedap.archie.aom.primitives.CTime;
+import com.nedap.archie.base.Interval;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by pieter.bos on 23/02/16.
+ */
+public class TimeConstraintsTest {
+
+    @Test
+    public void timeConstraints() {
+        CTime unconstrained = new CTime();
+        unconstrained.isValidValue(LocalTime.now());
+        unconstrained.isValidValue(LocalTime.of(12, 0));
+
+        CTime interval = new CTime();
+        interval.addConstraint(new Interval<>(LocalTime.of(11, 0), LocalTime.of(12, 0)));
+        assertTrue(interval.isValidValue(LocalTime.of(11, 0)));
+        assertTrue(interval.isValidValue(LocalTime.of(12, 0)));
+        assertFalse(interval.isValidValue(LocalTime.of(10, 59)));
+        assertFalse(interval.isValidValue(LocalTime.of(12, 1)));
+
+        CTime twoInterVals = new CTime();
+        interval.addConstraint(new Interval<>(LocalTime.of(11, 0), LocalTime.of(12, 0)));
+        interval.addConstraint(new Interval<>(LocalTime.of(10, 0), LocalTime.of(11, 0)));
+        assertTrue(interval.isValidValue(LocalTime.of(11, 0)));
+        assertTrue(interval.isValidValue(LocalTime.of(12, 0)));
+        assertTrue(interval.isValidValue(LocalTime.of(10, 59)));
+        assertFalse(interval.isValidValue(LocalTime.of(12, 1)));
+    }
+
+    //TODO: date patterns. also the implementation :)
+}


### PR DESCRIPTION
- Implements Interval.has(value)
- implement CPrimitiveObject.isValidValue(value)
- refactor the constraintToClassLookup mechanism so it is usable outside the ConstraintImposers
- create a basic RMObjectCreator, perhaps should call it prototypeCreator as it does not create entire RM graphs. It still needs work.