### PR TITLE
Profiles

### DIFF
--- a/src/main/java/com/nedap/archie/adlparser/odin/OdinToJsonConverter.java
+++ b/src/main/java/com/nedap/archie/adlparser/odin/OdinToJsonConverter.java
@@ -25,8 +25,7 @@ public class OdinToJsonConverter {
     private static ObjectMapper objectMapper = new ObjectMapper();
 
     static {
-        objectMapper.setPropertyNamingStrategy(
-                PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         //keywords = <"value"> is indistinguishable from keywords = <"value1", "value2">
         objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
@@ -48,7 +48,7 @@ public class CComplexObjectParser extends BaseTreeWalker {
         }
         //TODO: object.setDeprecated(context.) ?;
         if (context.c_occurrences() != null) {
-            object.setOccurences(parseMultiplicityInterval(context.c_occurrences()));
+            object.setOccurrences(parseMultiplicityInterval(context.c_occurrences()));
         }
         for (C_attribute_defContext attribute : context.c_attribute_def()) {
             parseCAttribute(object, attribute);
@@ -173,7 +173,7 @@ public class CComplexObjectParser extends BaseTreeWalker {
     private CComplexObjectProxy parseCComplexObjectProxy(C_complex_object_proxyContext proxyContext) {
 
         CComplexObjectProxy proxy = new CComplexObjectProxy();
-        proxy.setOccurences(this.parseMultiplicityInterval(proxyContext.c_occurrences()));
+        proxy.setOccurrences(this.parseMultiplicityInterval(proxyContext.c_occurrences()));
         proxy.setTargetPath(proxyContext.adl_path().getText());
         proxy.setRmTypeName(proxyContext.type_id().getText());
         proxy.setNodeId(proxyContext.ID_CODE().getText());
@@ -187,7 +187,7 @@ public class CComplexObjectParser extends BaseTreeWalker {
         root.setNodeId(archetypeRootContext.ID_CODE().getText());
         root.setArchetypeRef(archetypeRootContext.archetype_ref().getText());
 
-        root.setOccurences(this.parseMultiplicityInterval(archetypeRootContext.c_occurrences()));
+        root.setOccurrences(this.parseMultiplicityInterval(archetypeRootContext.c_occurrences()));
 //((Archetype_slotContext) slotContext).start.getInputStream().getText(slotContext.getSourceInterval())
         return root;
     }
@@ -201,7 +201,7 @@ public class CComplexObjectParser extends BaseTreeWalker {
             slot.setClosed(true);
         }
         if (headContext.c_occurrences() != null) {
-            slot.setOccurences(parseMultiplicityInterval(headContext.c_occurrences()));
+            slot.setOccurrences(parseMultiplicityInterval(headContext.c_occurrences()));
         }
         RulesParser assertionParser = new RulesParser(getErrors());
         if (slotContext.c_excludes() != null) {

--- a/src/main/java/com/nedap/archie/aom/CObject.java
+++ b/src/main/java/com/nedap/archie/aom/CObject.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class CObject extends ArchetypeConstraint {
 
     private String rmTypeName;
-    private MultiplicityInterval occurences;
+    private MultiplicityInterval occurrences;
     private String nodeId;
     private Boolean deprecated;
 
@@ -38,12 +38,12 @@ public class CObject extends ArchetypeConstraint {
         this.rmTypeName = rmTypeName;
     }
 
-    public MultiplicityInterval getOccurences() {
-        return occurences;
+    public MultiplicityInterval getOccurrences() {
+        return occurrences;
     }
 
-    public void setOccurences(MultiplicityInterval occurences) {
-        this.occurences = occurences;
+    public void setOccurrences(MultiplicityInterval occurrences) {
+        this.occurrences = occurrences;
     }
 
     public String getNodeId() {
@@ -163,10 +163,10 @@ public class CObject extends ArchetypeConstraint {
     }
 
     public boolean isAllowed() {
-        if(occurences == null) {
+        if(occurrences == null) {
             return true;
         }
-        return occurences.isUpperUnbounded() || occurences.getUpper() > 0;
+        return occurrences.isUpperUnbounded() || occurrences.getUpper() > 0;
     }
 
     @Override
@@ -175,10 +175,10 @@ public class CObject extends ArchetypeConstraint {
     }
 
     public boolean isRequired() {
-        if(occurences == null) {
+        if(occurrences == null) {
             return false;
         }
-        return occurences.getLower() > 0;
+        return occurrences.getLower() > 0;
     }
 
     /**

--- a/src/main/java/com/nedap/archie/aom/CPrimitiveObject.java
+++ b/src/main/java/com/nedap/archie/aom/CPrimitiveObject.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.aom;
 
+import com.nedap.archie.rminfo.ModelInfoLookup;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -74,6 +76,19 @@ public class CPrimitiveObject<Constraint, ValueType> extends CDefinedObject<Valu
             }
         }
         return false;
+    }
+
+    /**
+     * True if the given value is a valid value for this constraint
+     * first Converts the value to a checkable value using the given ModelInfoLookup
+     * For example when it is an interval or pattern
+     *
+     * @param value
+     * @return
+     */
+    public boolean isValidValue(ModelInfoLookup lookup, Object value) {
+        Object convertedValue = lookup.convertToConstraintObject(value, this);
+        return isValidValue((ValueType) convertedValue);
     }
 
     @Override

--- a/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -54,6 +54,9 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
         for(String constraint:getConstraint()) {
             if(constraint.startsWith("at")) {
                 ArchetypeTerm termDefinition = terminology.getTermDefinition(language, constraint);
+                if(termDefinition == null) {
+                    termDefinition = terminology.getTermDefinition(defaultLanguage, constraint);
+                }
                 if(termDefinition != null) {
                     result.add(new TerminologyCodeWithArchetypeTerm(constraint, termDefinition));
                 }

--- a/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -8,7 +8,6 @@ import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import com.nedap.archie.aom.terminology.TerminologyCodeWithArchetypeTerm;
 import com.nedap.archie.aom.terminology.ValueSet;
 import com.nedap.archie.base.terminology.TerminologyCode;
-import com.nedap.archie.rm.datatypes.CodePhrase;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,15 +18,8 @@ import java.util.List;
  */
 public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> {
 
+    @Override
     public boolean isValidValue(TerminologyCode value) {
-        return isValidValueCodePhrase(value);
-    }
-
-    public boolean isValidValue(CodePhrase value) {
-        return isValidValueCodePhrase(value);
-    }
-
-    private boolean isValidValueCodePhrase(CodePhrase value) {
         if(getConstraint().isEmpty()) {
             return true;
         }

--- a/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
+++ b/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
@@ -4,14 +4,21 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datatypes.TerminologyId;
 
+import java.net.URI;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * Created by pieter.bos on 15/10/15.
  */
-public class TerminologyCode extends CodePhrase {
+public class TerminologyCode {
+
+    private TerminologyId terminologyId;
     private String terminologyVersion;
+    private String codeString;
+
+    private URI uri;
+
 
     public TerminologyCode() {
         super();
@@ -60,5 +67,29 @@ public class TerminologyCode extends CodePhrase {
         return terminologyVersion == null ?
                 "[" + getTerminologyId() + "::" + getCodeString() + "]" :
                 "[" + getTerminologyId() + "(" + terminologyVersion + ")::" + getCodeString() + "]";
+    }
+
+    public TerminologyId getTerminologyId() {
+        return terminologyId;
+    }
+
+    public void setTerminologyId(TerminologyId terminologyId) {
+        this.terminologyId = terminologyId;
+    }
+
+    public String getCodeString() {
+        return codeString;
+    }
+
+    public void setCodeString(String codeString) {
+        this.codeString = codeString;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public void setUri(URI uri) {
+        this.uri = uri;
     }
 }

--- a/src/main/java/com/nedap/archie/creation/RMObjectCreator.java
+++ b/src/main/java/com/nedap/archie/creation/RMObjectCreator.java
@@ -43,7 +43,7 @@ public class RMObjectCreator {
             if(result instanceof Locatable) { //and most often, it will be
                 Locatable locatable = (Locatable) result;
                 locatable.setArchetypeNodeId(constraint.getNodeId());
-                locatable.setName(constraint.getMeaning());
+                locatable.setNameAsString(constraint.getMeaning());
             }
             return (T) result;
         } catch (InstantiationException | IllegalAccessException e) {

--- a/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -403,7 +403,7 @@ public class Flattener {
     }
 
     private void flattenCObject(CObject parent, CObject child) {
-        parent.setOccurences(getPossiblyOverridenValue(parent.getOccurences(), child.getOccurences()));
+        parent.setOccurrences(getPossiblyOverridenValue(parent.getOccurrences(), child.getOccurrences()));
         parent.setSiblingOrder(getPossiblyOverridenValue(parent.getSiblingOrder(), child.getSiblingOrder()));
 
         parent.setNodeId(getPossiblyOverridenValue(parent.getNodeId(), child.getNodeId()));

--- a/src/main/java/com/nedap/archie/rm/archetypes/Locatable.java
+++ b/src/main/java/com/nedap/archie/rm/archetypes/Locatable.java
@@ -1,6 +1,8 @@
 package com.nedap.archie.rm.archetypes;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datatypes.UIDBasedId;
@@ -49,8 +51,7 @@ public class Locatable extends Pathable {
     }
 
     /** convenience method*/
-    @XmlTransient
-    public void setName(String name) {
+    public void setNameAsString(String name) {
         this.name = new DvText(name);
     }
 

--- a/src/main/java/com/nedap/archie/rm/archetypes/Pathable.java
+++ b/src/main/java/com/nedap/archie/rm/archetypes/Pathable.java
@@ -11,6 +11,7 @@ import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlTransient;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -63,6 +64,18 @@ public class Pathable extends RMObject {
         if(child != null) {
             child.setParent(this);
             child.setParentAttributeName(attributeName);
+        }
+    }
+
+    /**
+     * Utility method to set this object as the parent of the given child,
+     * if the child is not null
+     */
+    protected void setThisAsParent(Collection<? extends Pathable> children, String attributeName) {
+        if(children != null) {
+            for(Pathable child:children) {
+                this.setThisAsParent(child, attributeName);
+            }
         }
     }
 

--- a/src/main/java/com/nedap/archie/rm/composition/Section.java
+++ b/src/main/java/com/nedap/archie/rm/composition/Section.java
@@ -23,13 +23,11 @@ public class Section extends ContentItem {
 
     public void setItems(List<ContentItem> items) {
         this.items = items;
-        for(ContentItem item:items) {
-            setThisAsParent(item, "item");
-        }
+        setThisAsParent(items, "items");
     }
 
     public void addItem(ContentItem item) {
         this.items.add(item);
-        setThisAsParent(item, "item");
+        setThisAsParent(item, "items");
     }
 }

--- a/src/main/java/com/nedap/archie/rm/datastructures/Cluster.java
+++ b/src/main/java/com/nedap/archie/rm/datastructures/Cluster.java
@@ -23,13 +23,13 @@ public class Cluster extends Item {
 
     public void setItems(List<Item> items) {
         this.items = items;
-        for(Item item:items) {
-            setThisAsParent(item, "item");
-        }
+
+        setThisAsParent(items, "items");
+
     }
 
     public void addItem(Item item) {
         items.add(item);
-        setThisAsParent(item, "item");
+        setThisAsParent(item, "items");
     }
 }

--- a/src/main/java/com/nedap/archie/rm/datastructures/History.java
+++ b/src/main/java/com/nedap/archie/rm/datastructures/History.java
@@ -66,14 +66,12 @@ public class History<Type extends ItemStructure> extends DataStructure {
 
     public void setEvents(List<Event<Type>> events) {
         this.events = events;
-        for(Event event:events) {
-            setThisAsParent(event, "event");
-        }
+        setThisAsParent(events, "events");
     }
 
     public void addEvent(Event<Type> event) {
         events.add(event);
-        setThisAsParent(event, "event");
+        setThisAsParent(event, "events");
     }
 
     @Nullable

--- a/src/main/java/com/nedap/archie/rm/datastructures/History.java
+++ b/src/main/java/com/nedap/archie/rm/datastructures/History.java
@@ -21,7 +21,7 @@ import java.util.List;
         "events",
         "summary"
 })
-public class History<Type extends ItemStructure> extends DataStructure {
+public final class History<Type extends ItemStructure> extends DataStructure {
 
     private DvDateTime origin;
     @Nullable

--- a/src/main/java/com/nedap/archie/rm/datastructures/ItemList.java
+++ b/src/main/java/com/nedap/archie/rm/datastructures/ItemList.java
@@ -23,9 +23,7 @@ public class ItemList extends ItemStructure<Element> {
 
         public void setItems(List<Element> items) {
                 this.items = items;
-                for(Element item:items) {
-                        setThisAsParent(item, "item");
-                }
+                setThisAsParent(items, "items");
         }
 
         public void addItem(Element item) {

--- a/src/main/java/com/nedap/archie/rm/datastructures/ItemTree.java
+++ b/src/main/java/com/nedap/archie/rm/datastructures/ItemTree.java
@@ -22,9 +22,7 @@ public class ItemTree extends ItemStructure<Item> {
 
         public void setItems(List<Item> items) {
                 this.items = items;
-                for(Item item:items) {
-                        setThisAsParent(item, "item");
-                }
+                setThisAsParent(items, "items");
         }
 
         public void addItem(Item item) {

--- a/src/main/java/com/nedap/archie/rm/datatypes/CodePhrase.java
+++ b/src/main/java/com/nedap/archie/rm/datatypes/CodePhrase.java
@@ -41,7 +41,7 @@ public class CodePhrase extends RMObject {
      */
     public CodePhrase(String phrase) {
         //'[' NAME_CHAR+ ( '(' NAME_CHAR+ ')' )? '::' NAME_CHAR+ ']' ;
-        Pattern pattern = Pattern.compile("\\[?(?<terminologyId>.+)(\\((?<terminologyVersion>.+)\\))?::(?<codeString>.+)\\]?");
+        Pattern pattern = Pattern.compile("\\[?(?<terminologyId>.+)(\\((?<terminologyVersion>.+)\\))?::(?<codeString>[^\\]]+)\\]?");
         Matcher matcher = pattern.matcher(phrase);
 
         if(matcher.matches()) {

--- a/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDate.java
+++ b/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDate.java
@@ -1,6 +1,8 @@
 package com.nedap.archie.rm.datavalues.quantity.datetime;
 
 import com.nedap.archie.rm.datavalues.SingleValuedDataValue;
+import com.nedap.archie.util.jaxbtime.DateXmlAdapter;
+import com.nedap.archie.util.jaxbtime.TimeXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -8,6 +10,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.YearMonth;
@@ -34,6 +37,7 @@ public class DvDate extends DvTemporal<Long> implements SingleValuedDataValue<Te
             @XmlElement(type=Year.class)
 
     })
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
     public Temporal getValue() {
         return value;
     }

--- a/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDateTime.java
+++ b/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDateTime.java
@@ -1,19 +1,16 @@
 package com.nedap.archie.rm.datavalues.quantity.datetime;
 
 import com.nedap.archie.rm.datavalues.SingleValuedDataValue;
+import com.nedap.archie.util.jaxbtime.DateTimeXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.time.*;
 import java.time.temporal.TemporalAccessor;
-import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQueries;
 
 /**
@@ -31,8 +28,8 @@ public class DvDateTime extends DvTemporal<Long> implements SingleValuedDataValu
     @XmlElements({
             @XmlElement(type = OffsetDateTime.class),
             @XmlElement(type = LocalDateTime.class)
-
     })
+    @XmlJavaTypeAdapter(DateTimeXmlAdapter.class)
     public TemporalAccessor getValue() {
         return value;
     }

--- a/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTime.java
+++ b/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTime.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rm.datavalues.quantity.datetime;
 
 import com.nedap.archie.rm.datavalues.SingleValuedDataValue;
+import com.nedap.archie.util.jaxbtime.TimeXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -8,6 +9,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetTime;
@@ -42,6 +44,7 @@ public class DvTime extends DvTemporal<Double> implements SingleValuedDataValue<
             @XmlElement(type=OffsetTime.class),
             @XmlElement(type=LocalTime.class)
     })
+    @XmlJavaTypeAdapter(TimeXmlAdapter.class)
     public TemporalAccessor getValue() {
         return value;
     }

--- a/src/main/java/com/nedap/archie/rm/directory/Folder.java
+++ b/src/main/java/com/nedap/archie/rm/directory/Folder.java
@@ -1,0 +1,54 @@
+package com.nedap.archie.rm.directory;
+
+import com.nedap.archie.rm.archetypes.Locatable;
+import com.nedap.archie.rm.datatypes.ObjectRef;
+import javax.annotation.Nullable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by pieter.bos on 21/06/16.
+ */
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(name = "FOLDER", propOrder = {
+        "items",
+        "folders"
+})
+public class Folder extends Locatable {
+    @Nullable
+    private List<ObjectRef> items = new ArrayList<>();
+    @Nullable
+    private List<Folder> folders = new ArrayList<>();
+
+    @Nullable
+    public List<ObjectRef> getItems() {
+        return items;
+    }
+
+    public void setItems(@Nullable List<ObjectRef> items) {
+        this.items = items;
+    }
+
+    public void addItem(ObjectRef item) {
+        this.items.add(item);
+    }
+
+    @Nullable
+    public List<Folder> getFolders() {
+        return folders;
+    }
+
+    public void setFolders(@Nullable List<Folder> folders) {
+        this.folders = folders;
+        setThisAsParent(folders, "folders");
+    }
+
+    public void addFolder(Folder folder) {
+        this.folders.add(folder);
+        this.setThisAsParent(folder, "folders");
+    }
+}

--- a/src/main/java/com/nedap/archie/rm/integration/GenericEntry.java
+++ b/src/main/java/com/nedap/archie/rm/integration/GenericEntry.java
@@ -1,0 +1,26 @@
+package com.nedap.archie.rm.integration;
+
+import com.nedap.archie.rm.composition.ContentItem;
+import com.nedap.archie.rm.datastructures.ItemTree;
+
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * Created by pieter.bos on 21/06/16.
+ */
+@XmlType(name = "GENERIC_ENTRY", propOrder = {
+        "data"
+})
+
+public class GenericEntry extends ContentItem {
+    private ItemTree data;
+
+    public ItemTree getData() {
+        return data;
+    }
+
+    public void setData(ItemTree data) {
+        this.data = data;
+        setThisAsParent(data, "data");
+    }
+}

--- a/src/main/java/com/nedap/archie/rm/package-info.java
+++ b/src/main/java/com/nedap/archie/rm/package-info.java
@@ -1,2 +1,6 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+
 package com.nedap.archie.rm;
+
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapters;

--- a/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -1,8 +1,13 @@
 package com.nedap.archie.rminfo;
 
+import com.nedap.archie.aom.CPrimitiveObject;
+import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.base.OpenEHRBase;
+import com.nedap.archie.base.terminology.TerminologyCode;
 import com.nedap.archie.rm.RMObject;
 import com.nedap.archie.rm.datastructures.PointEvent;
+import com.nedap.archie.rm.datatypes.CodePhrase;
+import com.nedap.archie.rm.datavalues.DvCodedText;
 
 /**
  * Created by pieter.bos on 02/02/16.
@@ -31,4 +36,23 @@ public class ArchieRMInfoLookup extends ModelInfoLookup {
         return getClass(rmTypename);
     }
 
+    @Override
+    public Object convertToConstraintObject(Object object, CPrimitiveObject cPrimitiveObject) {
+        if(cPrimitiveObject instanceof CTerminologyCode) {
+            if(object instanceof DvCodedText) {
+                return convertCodePhrase(((DvCodedText) object).getDefiningCode());
+            } else if (object instanceof CodePhrase) {
+                return convertCodePhrase((CodePhrase) object);
+            }
+        }
+        return object;
+    }
+
+    private TerminologyCode convertCodePhrase(CodePhrase codePhrase) {
+        TerminologyCode result = new TerminologyCode();
+        result.setCodeString(codePhrase.getCodeString());
+        result.setTerminologyId(codePhrase.getTerminologyId());
+        return result;
+    }
 }
+

--- a/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -54,5 +54,19 @@ public class ArchieRMInfoLookup extends ModelInfoLookup {
         result.setTerminologyId(codePhrase.getTerminologyId());
         return result;
     }
+
+    public Object convertConstrainedPrimitiveToRMObject(Object object) {
+        if(object instanceof TerminologyCode) {
+            return convertTerminologyCode((TerminologyCode) object);
+        }
+        return object;
+    }
+
+    private CodePhrase convertTerminologyCode(TerminologyCode terminologyCode) {
+        CodePhrase result = new CodePhrase();
+        result.setCodeString(terminologyCode.getCodeString());
+        result.setTerminologyId(terminologyCode.getTerminologyId());
+        return result;
+    }
 }
 

--- a/src/main/java/com/nedap/archie/rminfo/ModelInfoLookup.java
+++ b/src/main/java/com/nedap/archie/rminfo/ModelInfoLookup.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rminfo;
 
 import com.google.common.reflect.TypeToken;
+import com.nedap.archie.aom.CPrimitiveObject;
 import com.nedap.archie.rm.RMObject;
 import org.reflections.ReflectionUtils;
 import org.reflections.Reflections;
@@ -230,4 +231,16 @@ public class ModelInfoLookup {
         return namingStrategy;
     }
 
+    /**
+     * Convert the given reference model object to the object required for the archetype constraint.
+     *
+     * for example, a CTerminologyCode can be used to check a CodePhrase or a DvCodedText. This cannot be directly checked and must be converted first.
+     *
+     * @param object
+     * @param cPrimitiveObject
+     * @return
+     */
+    public Object convertToConstraintObject(Object object, CPrimitiveObject cPrimitiveObject) {
+        return object;
+    }
 }

--- a/src/main/java/com/nedap/archie/rminfo/ModelInfoLookup.java
+++ b/src/main/java/com/nedap/archie/rminfo/ModelInfoLookup.java
@@ -243,4 +243,9 @@ public class ModelInfoLookup {
     public Object convertToConstraintObject(Object object, CPrimitiveObject cPrimitiveObject) {
         return object;
     }
+
+    public Object convertConstrainedPrimitiveToRMObject(Object object) {
+        //TODO: this should take an AttributeInfo as param, so to be able to pick the right object
+        return object;
+    }
 }

--- a/src/main/java/com/nedap/archie/rules/evaluation/AssertionResult.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/AssertionResult.java
@@ -24,8 +24,18 @@ public class AssertionResult {
     private boolean result;
 
 
+    /**
+     * Paths that must have a specific value. Will be set even if this path already has the specific value,
+     * to let the UI know that this field can NOT manually be changed by the user right now
+     */
     private Map<String, Value> setPathValues = new LinkedHashMap<>();
+    /**
+     * Paths that must exist. Will be set even if it does exist, to let the UI know it should not be removed
+     */
     private List<String> pathsThatMustExist = new ArrayList<>();
+    /**
+     * Paths that must not exist. Will be set even if it does not exist, to let the UI know if should not be added.
+     */
     private List<String> pathsThatMustNotExist = new ArrayList<>();
 
     public String getTag() {

--- a/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
@@ -91,7 +91,13 @@ class FixableAssertionsChecker {
             if(existsOperator.getOperand() instanceof  ModelReference) { //TODO: this could also be an objectreference
                 //matches exists /path/to/value
                 List<ValueList> valueLists = ruleElementValues.get(existsOperator);
-                assertionResult.addPathsThatMustNotExist(resolveModelReferenceNonNull((ModelReference) existsOperator.getOperand(), index));
+                ValueList list = valueLists.get(index);
+                if(list.getSingleBooleanResult()) { //it exists. It should not
+                    assertionResult.addPathsThatMustNotExist(resolveModelReferenceNonNull((ModelReference) existsOperator.getOperand(), index));
+                } else { //does not exist, it's fine but we should still know. We need another model reference lookup method
+                    assertionResult.addPathThatMustNotExist(resolveModelReference((ModelReference) existsOperator.getOperand()));
+                }
+
             }
         }
     }
@@ -122,7 +128,7 @@ class FixableAssertionsChecker {
 
         ValueList pathExpressionValues = ruleElementValues.get(forAllStatement.getPathExpression()).get(0);
         for(ValueList valueList:valueLists) {
-            if(!valueList.getSingleBooleanResult()) {
+            //if(!valueList.getSingleBooleanResult()) {
                 //TODO: this code is a bit hard to understand
 
                 //set the variables to what they were during the for all evaluation.
@@ -140,7 +146,7 @@ class FixableAssertionsChecker {
 
                 forAllVariables.put(forAllStatement.getVariableName(), variableValue);
                 checkAssertionForFixablePatterns(assertionResult, forAllStatement.getRightOperand(), i);
-            }
+           // }
             i++;
         }
         forAllVariables.put(forAllStatement.getVariableName(), null);

--- a/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
@@ -121,9 +121,9 @@ public class RuleEvaluation {
         assertionResult.setResult(result);
         assertionResult.setRawResult(valueList);
         evaluationResult.addAssertionResult(assertionResult);
-        if(!assertionResult.getResult()) {
-            fixableAssertionsChecker.checkAssertionForFixablePatterns(assertionResult, expression, 0);
-        }
+
+        fixableAssertionsChecker.checkAssertionForFixablePatterns(assertionResult, expression, 0);
+
 
 
         //before re-evaluation, reset any overridden existence from evaluation?

--- a/src/main/java/com/nedap/archie/serializer/adl/ADLOdinObjectMapper.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/ADLOdinObjectMapper.java
@@ -8,6 +8,7 @@ import com.nedap.archie.aom.TranslationDetails;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import com.nedap.archie.aom.terminology.ValueSet;
+import com.nedap.archie.base.terminology.TerminologyCode;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.serializer.odin.OdinObject;
 
@@ -82,7 +83,7 @@ public class ADLOdinObjectMapper implements Function<Object, Object> {
 
     private OdinObject map(ResourceDescription desc) {
         return new OdinObject()
-                .put("lifecycle_state", ofNullable(desc.getLifecycleState()).map(CodePhrase::getCodeString))
+                .put("lifecycle_state", ofNullable(desc.getLifecycleState()).map(TerminologyCode::getCodeString))
                 .put("original_author", desc.getOriginalAuthor())
                 .put("original_publisher", desc.getOriginalPublisher())
                 .put("original_namespace", desc.getOriginalNamespace())

--- a/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
@@ -47,9 +47,9 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
                 .append("allow_archetype")
                 .append(" ")
                 .append(cobj.getRmTypeName()).append("[").append(cobj.getNodeId()).append("]");
-        if (cobj.getOccurences() != null) {
+        if (cobj.getOccurrences() != null) {
             builder.append(" occurrences matches {");
-            ArchetypeSerializeUtils.buildOccurrences(builder, cobj.getOccurences());
+            ArchetypeSerializeUtils.buildOccurrences(builder, cobj.getOccurrences());
             builder.append("}");
         }
         if (cobj.isClosed()) {

--- a/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
@@ -50,9 +50,9 @@ public class CComplexObjectSerializer<T extends CComplexObject> extends Constrai
             builder.append("[").append(cobj.getNodeId()).append("]");
         }
         builder.append(" ");
-        if (cobj.getOccurences() != null) {
+        if (cobj.getOccurrences() != null) {
             builder.append("occurrences matches {");
-            buildOccurrences(builder, cobj.getOccurences());
+            buildOccurrences(builder, cobj.getOccurrences());
             builder.append("} ");
         }
         if (cobj.getAttributes().isEmpty() && cobj.getAttributeTuples().isEmpty()) {

--- a/src/main/java/com/nedap/archie/util/jaxbtime/DateTimeXmlAdapter.java
+++ b/src/main/java/com/nedap/archie/util/jaxbtime/DateTimeXmlAdapter.java
@@ -1,0 +1,32 @@
+package com.nedap.archie.util.jaxbtime;
+
+import com.nedap.archie.adlparser.treewalkers.TemporalConstraintParser;
+
+import javax.annotation.Nonnull;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQuery;
+import java.util.Objects;
+
+/**
+ * Created by pieter.bos on 24/06/16.
+ */
+public class DateTimeXmlAdapter extends XmlAdapter<String, TemporalAccessor> {
+
+
+    public DateTimeXmlAdapter() {
+
+    }
+
+    @Override
+    public TemporalAccessor unmarshal(String stringValue) {
+        return stringValue != null? TemporalConstraintParser.parseDateTimeValue(stringValue):null;
+    }
+
+    @Override
+    public String marshal(TemporalAccessor value) {
+        return value != null?TemporalConstraintParser.ISO_8601_DATE_TIME.format(value):null;
+    }
+
+}

--- a/src/main/java/com/nedap/archie/util/jaxbtime/DateXmlAdapter.java
+++ b/src/main/java/com/nedap/archie/util/jaxbtime/DateXmlAdapter.java
@@ -1,0 +1,27 @@
+package com.nedap.archie.util.jaxbtime;
+
+import com.nedap.archie.adlparser.treewalkers.TemporalConstraintParser;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * Created by pieter.bos on 24/06/16.
+ */
+public class DateXmlAdapter extends XmlAdapter<String, Temporal> {
+
+    public DateXmlAdapter() {
+
+    }
+
+    @Override
+    public Temporal unmarshal(String stringValue) {
+        return stringValue != null? TemporalConstraintParser.parseDateValue(stringValue):null;
+    }
+
+    @Override
+    public String marshal(Temporal value) {
+        return value != null?TemporalConstraintParser.ISO_8601_DATE.format(value):null;
+    }
+}

--- a/src/main/java/com/nedap/archie/util/jaxbtime/TimeXmlAdapter.java
+++ b/src/main/java/com/nedap/archie/util/jaxbtime/TimeXmlAdapter.java
@@ -1,0 +1,27 @@
+package com.nedap.archie.util.jaxbtime;
+
+import com.nedap.archie.adlparser.treewalkers.TemporalConstraintParser;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * Created by pieter.bos on 24/06/16.
+ */
+public class TimeXmlAdapter extends XmlAdapter<String, TemporalAccessor> {
+
+    public TimeXmlAdapter() {
+
+    }
+
+    @Override
+    public TemporalAccessor unmarshal(String stringValue) {
+        return stringValue != null? TemporalConstraintParser.parseTimeValue(stringValue):null;
+    }
+
+    @Override
+    public String marshal(TemporalAccessor value) {
+        return value != null?TemporalConstraintParser.ISO_8601_TIME.format(value):null;
+    }
+}

--- a/src/test/java/com/nedap/archie/adlparser/DefinitionTest.java
+++ b/src/test/java/com/nedap/archie/adlparser/DefinitionTest.java
@@ -29,7 +29,7 @@ public class DefinitionTest {
         CComplexObject definition = archetype.getDefinition();
         assertEquals("COMPOSITION", definition.getRmTypeName());
         assertEquals("id1", definition.getNodeId());
-        assertNull(definition.getOccurences());
+        assertNull(definition.getOccurrences());
 
         List<CAttribute> attributes = definition.getAttributes();
         assertEquals(3, attributes.size());
@@ -40,7 +40,7 @@ public class DefinitionTest {
         CComplexObject categoryDefinition = (CComplexObject) categoryChildren.get(0);
         assertEquals("DV_CODED_TEXT", categoryDefinition.getRmTypeName());
         assertEquals("id10", categoryDefinition.getNodeId());
-        assertNull(categoryDefinition.getOccurences());
+        assertNull(categoryDefinition.getOccurrences());
         assertNull(categoryDefinition.getDefaultValue());
         CTerminologyCode code = (CTerminologyCode) categoryDefinition.getAttribute("defining_code").getChildren().get(0);
 

--- a/src/test/java/com/nedap/archie/aom/AttributeTupleConstraintsTest.java
+++ b/src/test/java/com/nedap/archie/aom/AttributeTupleConstraintsTest.java
@@ -2,6 +2,8 @@ package com.nedap.archie.aom;
 
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.rm.datavalues.quantity.DvQuantity;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import com.nedap.archie.rminfo.ModelInfoLookup;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -15,6 +17,8 @@ import static org.junit.Assert.*;
 public class AttributeTupleConstraintsTest {
 
     static CAttributeTuple attributeTuple;
+
+    private ModelInfoLookup lookup = ArchieRMInfoLookup.getInstance();
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
+++ b/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
@@ -2,6 +2,9 @@ package com.nedap.archie.aom;
 
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.base.terminology.TerminologyCode;
+import com.nedap.archie.rm.datatypes.CodePhrase;
+import com.nedap.archie.rm.datavalues.DvCodedText;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -34,5 +37,18 @@ public class TerminologyCodeConstraintsTest {
         assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac12::at23]")));
         assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac13::at23]")));
         assertFalse(code.isValidValue(TerminologyCode.createFromString("[ac13::at24]")));
+    }
+
+    @Test
+    public void dvCodedText() {
+        //DV_CODED_TEXT can be constrained by a C_TERMINOLOGY_CONSTRAINT, according to lots of DV_ORDINAL usage in the CKM
+        CTerminologyCode code = new CTerminologyCode();
+        code.addConstraint("at23");
+        DvCodedText text = new DvCodedText();
+        text.setValue("does not matter for this validation");
+        text.setDefiningCode(new CodePhrase("[ac12::at23]"));
+        assertTrue(code.isValidValue(ArchieRMInfoLookup.getInstance(), text));
+        text.setDefiningCode(new CodePhrase("[ac13::at24]"));
+        assertFalse(code.isValidValue(ArchieRMInfoLookup.getInstance(), text));
     }
 }

--- a/src/test/java/com/nedap/archie/rm/LocatableTest.java
+++ b/src/test/java/com/nedap/archie/rm/LocatableTest.java
@@ -34,7 +34,7 @@ public class LocatableTest {
         PointEvent event = new PointEvent<>();
         history.addEvent(event);
         event.setArchetypeNodeId("id3");
-        event.setName("custom event");
+        event.setNameAsString("custom event");
         ItemTree itemTree = new ItemTree();
         event.setData(itemTree);
         itemTree.setArchetypeNodeId("id4");
@@ -75,7 +75,7 @@ public class LocatableTest {
         PointEvent event = new PointEvent<>();
         history.addEvent(event);
         event.setArchetypeNodeId("id3");
-        event.setName("custom event");
+        event.setNameAsString("custom event");
         ItemTree itemTree = new ItemTree();
         event.setData(itemTree);
         itemTree.setArchetypeNodeId("id4");

--- a/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -323,7 +323,7 @@ public class ParsedRulesEvaluationTest {
             assertTrue(assertionResult.getResult());//TODO: check paths that caused this
         }
 
-        assertEquals(0, evaluationResult.getPathsThatMustExist().size());
+        assertEquals(4, evaluationResult.getPathsThatMustExist().size());
         assertEquals(0, evaluationResult.getPathsThatMustNotExist().size());
         assertEquals(0, evaluationResult.getSetPathValues().size());
 
@@ -366,7 +366,8 @@ public class ParsedRulesEvaluationTest {
         }
 
         assertEquals(0, evaluationResult.getPathsThatMustExist().size());
-        assertEquals(0, evaluationResult.getPathsThatMustNotExist().size());
+        //the paths should not be creatable, so they should still be present in the result
+        assertEquals(3, evaluationResult.getPathsThatMustNotExist().size());
         assertEquals(0, evaluationResult.getSetPathValues().size());
 
     }
@@ -404,7 +405,9 @@ public class ParsedRulesEvaluationTest {
         assertFalse(evaluationResult.getAssertionResults().get(2).getResult()); //for all exists systolic - this is not true, so failed
 
 
-        assertEquals(1, evaluationResult.getPathsThatMustExist().size());
+        //four paths evaluated to exist, so ALL of them will be added to the list
+        assertEquals(4, evaluationResult.getPathsThatMustExist().size());
+
 
         assertEquals(0, evaluationResult.getPathsThatMustNotExist().size());
         //this is the most specific path we can construct to the missing node, using the for_all variable context
@@ -429,7 +432,7 @@ public class ParsedRulesEvaluationTest {
         }
 
         assertEquals(0, evaluationResult.getPathsThatMustExist().size());
-        assertEquals(4, evaluationResult.getPathsThatMustNotExist().size());
+        assertEquals(5, evaluationResult.getPathsThatMustNotExist().size());
         assertTrue(evaluationResult.getPathsThatMustNotExist().contains("/data[id2, 1]/events[id3, 1]/data[id4, 1]/items[id5, 1]/value[1]/magnitude[1]"));
         assertTrue(evaluationResult.getPathsThatMustNotExist().contains("/data[id2, 1]/events[id3, 2]/data[id4, 1]/items[id6, 2]/value[1]/magnitude[1]"));
         assertEquals(0, evaluationResult.getSetPathValues().size());


### PR DESCRIPTION
Some backwards incompatible changes:
- rename occurences to the correct occurrences
- ```Locatable::setName(String)``` renamed to setNameAsString. setName(DvText) still is the same. Needed for JSON deserialization to work correctly
- ModelInfoLookup now has two extra methods ```convertToConstraintObject``` and ```convertConstrainedPrimitiveToRMObject```. This is used to convert between RM Objects and Archetype model objects. the ```CPrimitiveObject::isValidValue(Object)``` methods automatically do this, or alternatively you can pass a ModelInfoLookup instance as second parameter.
This solves a hack where TerminologyCode inherits from CodePhrase, as well as some other problems. This no longer is the case and conversions happen where needed. This is documented under profiles in the openEHR specification. It may cause changes in object validation logic in applications using Archie.

- AssertionResult now includes pathsThatMustExist, pathsThatMustNotExist and setPathValues even if the assertion result succeeded.
This can be used in UIs: when checking rules first, you change the model. When checking again, you would not get the same results back. While the 'exists ...' means that this item should not be deletable, and you would not know. Now you do know, and can make the field/item/whatever non-deletable in interfaces for user input. This can change

backwards-compatible changes:

Refactor
- setThisAsParent now works with collection (saves some code and mistakes)

Bugfixes:
- bugfix in codephrase parsing
- CTerminologyCode did not use correct fallback translation language in some cases
- Date/DateTime/Time XML (de)serialization now works correctly

RM Model additions
- Folder and GenericEntry added to RM