### PR TITLE
Add missing occurrences and node_id to adl serializer

### DIFF
--- a/src/main/java/com/nedap/archie/serializer/adl/ADLOdinObjectMapper.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/ADLOdinObjectMapper.java
@@ -107,7 +107,7 @@ public class ADLOdinObjectMapper implements Function<Object, Object> {
                 .put("use", rdi.getUse())
                 .put("misuse", rdi.getMisuse())
                 .put("keywords", rdi.getKeywords())
-                .put(rdi.getCopyright(), rdi.getCopyright())
+                .put("copyright", rdi.getCopyright())
                 .put("original_resource_uri", rdi.getOriginalResourceUri())
                 .put("other_details", rdi.getOtherDetails());
     }

--- a/src/main/java/com/nedap/archie/serializer/adl/ADLStringBuilder.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/ADLStringBuilder.java
@@ -86,5 +86,9 @@ public class ADLStringBuilder implements StructuredStringAppendable {
     }
 
 
+    public ADLStringBuilder ensureSpace() {
+        builder.ensureSpace();
+        return this;
+    }
 }
 

--- a/src/main/java/com/nedap/archie/serializer/adl/constraints/CArchetypeRootSerializer.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/constraints/CArchetypeRootSerializer.java
@@ -44,6 +44,9 @@ public class CArchetypeRootSerializer extends ConstraintSerializer<CArchetypeRoo
         builder.append(cobj.getArchetypeRef());
         builder.append("]");
 
+        appendOccurrences(cobj);
+
+
         builder.unindent();
     }
 }

--- a/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectProxySerializer.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectProxySerializer.java
@@ -16,12 +16,13 @@ public class CComplexObjectProxySerializer extends ConstraintSerializer<CComplex
         builder.newIndentedLine()
                 .append("use_node ")
                 .append(cobj.getRmTypeName())
-                .append(nodeIdString(cobj.getNodeId()))
-                .append(" ")
-                .append(cobj.getTargetPath())
+                .append(nodeIdString(cobj.getNodeId()));
+        appendOccurrences(cobj);
+        builder.ensureSpace().append(cobj.getTargetPath())
                 //.lineComment("Should be comment here - not implemented")
                 .unindent();
     }
+
 
     private String nodeIdString(String nodeId) {
         return nodeId == null ? "" : "[" + nodeId + "]";

--- a/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectProxySerializer.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectProxySerializer.java
@@ -6,7 +6,7 @@ import com.nedap.archie.serializer.adl.ADLDefinitionSerializer;
 /**
  * @author markopi
  */
-public class CComplexObjectProxySerializer extends ConstraintSerializer<CComplexObjectProxy>  {
+public class CComplexObjectProxySerializer extends ConstraintSerializer<CComplexObjectProxy> {
     public CComplexObjectProxySerializer(ADLDefinitionSerializer serializer) {
         super(serializer);
     }
@@ -16,9 +16,14 @@ public class CComplexObjectProxySerializer extends ConstraintSerializer<CComplex
         builder.newIndentedLine()
                 .append("use_node ")
                 .append(cobj.getRmTypeName())
+                .append(nodeIdString(cobj.getNodeId()))
                 .append(" ")
                 .append(cobj.getTargetPath())
                 //.lineComment("Should be comment here - not implemented")
                 .unindent();
+    }
+
+    private String nodeIdString(String nodeId) {
+        return nodeId == null ? "" : "[" + nodeId + "]";
     }
 }

--- a/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
@@ -49,11 +49,7 @@ public class CComplexObjectSerializer<T extends CComplexObject> extends Constrai
             builder.append("[").append(cobj.getNodeId()).append("]");
         }
         builder.append(" ");
-        if (cobj.getOccurrences() != null) {
-            builder.append("occurrences matches {");
-            buildOccurrences(builder, cobj.getOccurrences());
-            builder.append("} ");
-        }
+        appendOccurrences(cobj);
         if (cobj.getAttributes().isEmpty() && cobj.getAttributeTuples().isEmpty()) {
             builder.lineComment(serializer.getTermText(cobj));
         } else {

--- a/src/main/java/com/nedap/archie/serializer/adl/constraints/ConstraintSerializer.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/constraints/ConstraintSerializer.java
@@ -25,6 +25,8 @@ import com.nedap.archie.aom.CObject;
 import com.nedap.archie.serializer.adl.ADLDefinitionSerializer;
 import com.nedap.archie.serializer.adl.ADLStringBuilder;
 
+import static com.nedap.archie.serializer.adl.ArchetypeSerializeUtils.buildOccurrences;
+
 /**
  * @author Marko Pipan
  */
@@ -53,5 +55,14 @@ public abstract class ConstraintSerializer<T extends CObject> {
 
     public void revert(int previousMark) {
         builder.revert(previousMark);
+    }
+
+    protected void appendOccurrences(T cobj) {
+        if (cobj.getOccurrences() != null) {
+            builder.ensureSpace();
+            builder.append("occurrences matches {");
+            buildOccurrences(builder, cobj.getOccurrences());
+            builder.append("} ");
+        }
     }
 }

--- a/src/main/java/com/nedap/archie/serializer/odin/StructureStringBuilder.java
+++ b/src/main/java/com/nedap/archie/serializer/odin/StructureStringBuilder.java
@@ -11,9 +11,30 @@ public class StructureStringBuilder implements StructuredStringAppendable {
     private final StringBuilder builder = new StringBuilder();
     private int indentDepth = 0;
     private boolean startOfLine = true;
-    private int startOfLineIndex=0;
+    private int startOfLineIndex = 0;
 
     public StructureStringBuilder() {
+    }
+
+    public static String padRight(String str, int size) {
+        return padRight(str, size, ' ');
+    }
+
+    private static String padRight(String str, int size, char padChar) {
+        if (str == null) {
+            return null;
+        }
+        int pads = size - str.length();
+        if (pads <= 0) {
+            return str;
+        }
+        return str + padding(padChar, pads);
+    }
+
+    private static String padding(char padChar, int repeat) throws IndexOutOfBoundsException {
+        final char[] buf = new char[repeat];
+        Arrays.fill(buf, padChar);
+        return new String(buf);
     }
 
     @Override
@@ -31,15 +52,6 @@ public class StructureStringBuilder implements StructuredStringAppendable {
             resetLineIndentation();
         }
         return this;
-    }
-
-    private void resetLineIndentation() {
-        builder.setLength(startOfLineIndex);
-        appendIndentation();
-    }
-
-    private void appendIndentation() {
-        builder.append(padding(' ', indentDepth * INDENTATION_SIZE));
     }
 
     @Override
@@ -74,11 +86,6 @@ public class StructureStringBuilder implements StructuredStringAppendable {
     }
 
     @Override
-    public String toString() {
-        return builder.toString();
-    }
-
-    @Override
     public int mark() {
         return builder.length();
     }
@@ -88,25 +95,27 @@ public class StructureStringBuilder implements StructuredStringAppendable {
         builder.setLength(previousMark);
     }
 
-    public static String padRight(String str, int size) {
-        return padRight(str, size, ' ');
+    @Override
+    public StructuredStringAppendable ensureSpace() {
+        if (builder.length() == 0) return this;
+        char lastChar = builder.charAt(builder.length() - 1);
+        if (Character.isWhitespace(lastChar)) return this;
+        builder.append(" ");
+        return this;
     }
 
-    private static String padRight(String str, int size, char padChar) {
-        if (str == null) {
-            return null;
-        }
-        int pads = size - str.length();
-        if (pads <= 0) {
-            return str;
-        }
-        return str + padding(padChar, pads);
+    private void resetLineIndentation() {
+        builder.setLength(startOfLineIndex);
+        appendIndentation();
     }
 
-    private static String padding(char padChar, int repeat) throws IndexOutOfBoundsException {
-        final char[] buf = new char[repeat];
-        Arrays.fill(buf, padChar);
-        return new String(buf);
+    private void appendIndentation() {
+        builder.append(padding(' ', indentDepth * INDENTATION_SIZE));
+    }
+
+    @Override
+    public String toString() {
+        return builder.toString();
     }
 
 }

--- a/src/main/java/com/nedap/archie/serializer/odin/StructuredStringAppendable.java
+++ b/src/main/java/com/nedap/archie/serializer/odin/StructuredStringAppendable.java
@@ -20,4 +20,5 @@ public interface StructuredStringAppendable {
 
     void revert(int previousMark);
 
+    StructuredStringAppendable ensureSpace();
 }

--- a/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -10,6 +10,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -244,7 +245,6 @@ public class ADLDefinitionSerializerTest {
                 "    }"));
 
 
-
         archetype = load("openEHR-EHR-CLUSTER.device.v1.adls");
         slot = archetype.itemAtPath("/items[id10]");
         serialized = serializeConstraint(slot);
@@ -261,6 +261,33 @@ public class ADLDefinitionSerializerTest {
                 "        exclude\n" +
                 "            archetype_id/value matches {/openEHR-EHR-OBSERVATION\\.blood_pressure([a-zA-Z0-9_]+)*\\.v1/}\n" +
                 "    }"));
+    }
+
+    @Test
+    public void serializeCArchetypeRoot() throws IOException {
+        Archetype archetype = loadRoot("adl2-tests/features/aom_structures/use_archetype/openEHR-EHR-COMPOSITION.ext_ref.v1.adls");
+
+        List<CObject> archetypeRoots = archetype.getDefinition().getAttribute("content").getChildren();
+
+        assertThat(serializeConstraint(archetypeRoots.get(0)).trim(),
+                equalTo("use_archetype SECTION[id2, openEHR-EHR-SECTION.section_parent.v1] occurrences matches {0..1}"));
+        assertThat(serializeConstraint(archetypeRoots.get(1)).trim(),
+                equalTo("use_archetype OBSERVATION[id3, openEHR-EHR-OBSERVATION.spec_test_obs.v1] occurrences matches {1}"));
+    }
+
+    @Test
+    public void serializeCComplexObjectProxy() throws IOException {
+        Archetype archetype = loadRoot("adl2-tests/features/aom_structures/use_node/openEHR-DEMOGRAPHIC-PERSON.use_node_occurrences.v1.adls");
+
+        CObject parentCObj = archetype.getDefinition().itemAtPath("/contacts[id10]");
+        List<CObject> ccobjProxies = parentCObj.getAttribute("addresses").getChildren();
+
+        assertThat(serializeConstraint(ccobjProxies.get(0)).trim(),
+                equalTo("use_node ADDRESS[id11] /contacts[id6]/addresses[id7]"));
+        assertThat(serializeConstraint(ccobjProxies.get(1)).trim(),
+                equalTo("use_node ADDRESS[id12] /contacts[id6]/addresses[id8]"));
+        assertThat(serializeConstraint(ccobjProxies.get(2)).trim(),
+                equalTo("use_node ADDRESS[id13] occurrences matches {1..3} /contacts[id6]/addresses[id9]"));
     }
 
 


### PR DESCRIPTION
Fixed some issues on adl serializer:
* node_id was not serialized in CComplexObjectProxy
* serialization of copyright field in ResourceDescriptionItem was wrong
* occurrences were not serialized in CComplexObjectProxy and CArchetypeRoot. 
