### PR TITLE
Updated grammar

### DIFF
--- a/src/main/antlr/adl_rules.g4
+++ b/src/main/antlr/adl_rules.g4
@@ -53,31 +53,20 @@ boolean_xor_expression
 
 boolean_constraint_expression
     : boolean_constraint
-    | boolean_leaf;
+    | arithmetic_relop_expr;
 
 
 boolean_constraint: ( adl_rules_path | adl_rules_relative_path ) SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
 
-boolean_leaf:
-      boolean_literal
-    //| adl_path
-    | variable_reference
-    | SYM_EXISTS adl_rules_path
-    | '(' boolean_expression ')'
-    | arithmetic_relop_expr
-    | SYM_NOT boolean_leaf
-    ;
 
-boolean_literal:
-      SYM_TRUE
-    | SYM_FALSE
-    ;
 
 //
 // Expressions evaluating to arithmetic values
 //
 
-arithmetic_relop_expr: arithmetic_expression relational_binop arithmetic_expression ;
+arithmetic_relop_expr:
+    arithmetic_expression
+    | arithmetic_relop_expr relational_binop arithmetic_expression ;
 
 
 arithmetic_expression
@@ -96,11 +85,14 @@ pow_expression
    ;
 
 arithmetic_leaf:
-      integer_value
+      boolean_literal
+    | integer_value
     | real_value
     | adl_rules_path
+    | SYM_EXISTS adl_rules_path
+    | SYM_NOT boolean_expression
     | variable_reference
-    | '(' arithmetic_expression ')'
+    | '(' boolean_expression ')'
     | '-' arithmetic_leaf
     ;
 
@@ -121,6 +113,11 @@ relational_binop:
     | '<'
     | '>='
     | '>'
+    ;
+
+boolean_literal:
+      SYM_TRUE
+    | SYM_FALSE
     ;
 
 SYM_FOR_ALL:

--- a/src/main/antlr/adl_rules.g4
+++ b/src/main/antlr/adl_rules.g4
@@ -16,47 +16,47 @@ import cadl_primitives;
 
 assertion_list: (assertion (';'))+ ;// {_input.LA(1) == WS || _input.LA(1) == LINE}?) +;//whitespace parsing to prevent ambiguity
 
-assertion: variable_declaration | boolean_assertion;
+assertion: variableDeclaration | booleanAssertion;
 
-variable_declaration: SYM_VARIABLE_START identifier SYM_COLON identifier SYM_ASSIGNMENT (boolean_expression | arithmetic_expression);
+variableDeclaration: SYM_VARIABLE_START identifier SYM_COLON identifier SYM_ASSIGNMENT (booleanExpression | plusExpression);
 
-boolean_assertion: ( identifier SYM_COLON )? boolean_expression ;
+booleanAssertion: ( identifier SYM_COLON )? booleanExpression ;
 
 //
 // Expressions evaluating to boolean values
 //
 
 
-boolean_expression
-    : boolean_for_all_expression
-    | boolean_expression SYM_IMPLIES boolean_for_all_expression
+booleanExpression
+    : booleanForAllExpression
+    | booleanExpression SYM_IMPLIES booleanForAllExpression
     ;
 
-boolean_for_all_expression
-    : boolean_or_expression
-    | SYM_FOR_ALL SYM_VARIABLE_START identifier SYM_IN (adl_rules_path | variable_reference) SYM_SATISFIES? boolean_for_all_expression;
+booleanForAllExpression
+    : booleanOrExpression
+    | SYM_FOR_ALL SYM_VARIABLE_START identifier SYM_IN (adlRulesPath | variableReference) SYM_SATISFIES? booleanForAllExpression;
 
-boolean_or_expression
-    : boolean_and_expression
-    | boolean_or_expression SYM_OR boolean_and_expression
+booleanOrExpression
+    : booleanAndExpression
+    | booleanOrExpression SYM_OR booleanAndExpression
     ;
 
-boolean_and_expression
-	:	boolean_xor_expression
-	|	boolean_and_expression SYM_AND boolean_xor_expression
+booleanAndExpression
+	:	booleanXorExpression
+	|	booleanAndExpression SYM_AND booleanXorExpression
 	;
 
-boolean_xor_expression
-	:	boolean_constraint_expression
-	|	boolean_xor_expression SYM_XOR boolean_constraint_expression
+booleanXorExpression
+	:	booleanConstraintExpression
+	|	booleanXorExpression SYM_XOR booleanConstraintExpression
 	;
 
-boolean_constraint_expression
-    : boolean_constraint
-    | arithmetic_relop_expr;
+booleanConstraintExpression
+    : booleanConstraint
+    | equalityExpression;
 
 
-boolean_constraint: ( adl_rules_path | adl_rules_relative_path ) SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
+booleanConstraint: ( adlRulesPath | adlRulesRelativePath ) SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
 
 
 
@@ -64,58 +64,65 @@ boolean_constraint: ( adl_rules_path | adl_rules_relative_path ) SYM_MATCHES ('{
 // Expressions evaluating to arithmetic values
 //
 
-arithmetic_relop_expr:
-    arithmetic_expression
-    | arithmetic_relop_expr relational_binop arithmetic_expression ;
+equalityExpression:
+    relOpExpression
+    | equalityExpression equalityBinop relOpExpression ;
+
+relOpExpression:
+    plusExpression
+    | relOpExpression relationalBinop plusExpression ;
 
 
-arithmetic_expression
-   : multiplying_expression
-   | arithmetic_expression plus_minus_binop multiplying_expression
+plusExpression
+   : multiplyingExpression
+   | plusExpression plusMinusBinop multiplyingExpression
    ;
 
-multiplying_expression
-   : pow_expression
-   | multiplying_expression mult_binop pow_expression
+multiplyingExpression
+   : powExpression
+   | multiplyingExpression mult_binop powExpression
    ;
 
-pow_expression
-   : arithmetic_leaf
-   | <assoc=right> pow_expression '^' arithmetic_leaf
+powExpression
+   : expressionLeaf
+   | <assoc=right> powExpression '^' expressionLeaf
    ;
 
-arithmetic_leaf:
-      boolean_literal
+expressionLeaf:
+      booleanLiteral
     | integer_value
     | real_value
-    | adl_rules_path
-    | SYM_EXISTS adl_rules_path
-    | SYM_NOT boolean_expression
-    | variable_reference
-    | '(' boolean_expression ')'
-    | '-' arithmetic_leaf
+    | adlRulesPath
+    | SYM_EXISTS adlRulesPath
+    | SYM_NOT booleanExpression
+    | variableReference
+    | '(' booleanExpression ')'
+    | '-' expressionLeaf
     ;
 
-adl_rules_path          : variable_reference? adl_rules_path_segment+;//(adl_path_segment ({_input.LA(-1) != WS && _input.LA(-1) != LINE}?))+ adl_path_segment? ;
-adl_rules_relative_path : adl_rules_path_element adl_rules_path ;  // TODO: remove when current slots no longer needed
-adl_rules_path_segment  : ('/' | '//') adl_rules_path_element;
-adl_rules_path_element  : attribute_id ( '[' (ID_CODE | ARCHETYPE_REF) ']' )?;
+adlRulesPath          : variableReference? adlRulesPathSegment+;//(adl_path_segment ({_input.LA(-1) != WS && _input.LA(-1) != LINE}?))+ adl_path_segment? ;
+adlRulesRelativePath : adlRulesPathElement adlRulesPath ;  // TODO: remove when current slots no longer needed
+adlRulesPathSegment  : ('/' | '//') adlRulesPathElement;
+adlRulesPathElement  : attribute_id ( '[' (ID_CODE | ARCHETYPE_REF) ']' )?;
 
-variable_reference: SYM_VARIABLE_START identifier;
+variableReference: SYM_VARIABLE_START identifier;
 
-plus_minus_binop: '+' | '-';
+plusMinusBinop: '+' | '-';
 mult_binop: '*' | '/' | '%';
 
-relational_binop:
+equalityBinop:
       '='
     | '!='
+    ;
+
+relationalBinop:
     | '<='
     | '<'
     | '>='
     | '>'
     ;
 
-boolean_literal:
+booleanLiteral:
       SYM_TRUE
     | SYM_FALSE
     ;

--- a/src/main/antlr/adl_rules.g4
+++ b/src/main/antlr/adl_rules.g4
@@ -58,12 +58,6 @@ booleanConstraintExpression
 
 booleanConstraint: ( adlRulesPath | adlRulesRelativePath ) SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
 
-
-
-//
-// Expressions evaluating to arithmetic values
-//
-
 equalityExpression:
     relOpExpression
     | equalityExpression equalityBinop relOpExpression ;
@@ -73,6 +67,10 @@ relOpExpression:
     | relOpExpression relationalBinop plusExpression ;
 
 
+//
+// Expressions evaluating to all kinds of value types
+//
+
 plusExpression
    : multiplyingExpression
    | plusExpression plusMinusBinop multiplyingExpression
@@ -80,7 +78,7 @@ plusExpression
 
 multiplyingExpression
    : powExpression
-   | multiplyingExpression mult_binop powExpression
+   | multiplyingExpression multBinop powExpression
    ;
 
 powExpression
@@ -100,15 +98,15 @@ expressionLeaf:
     | '-' expressionLeaf
     ;
 
-adlRulesPath          : variableReference? adlRulesPathSegment+;//(adl_path_segment ({_input.LA(-1) != WS && _input.LA(-1) != LINE}?))+ adl_path_segment? ;
-adlRulesRelativePath : adlRulesPathElement adlRulesPath ;  // TODO: remove when current slots no longer needed
+adlRulesPath          : variableReference? adlRulesPathSegment+;
+adlRulesRelativePath : adlRulesPathElement adlRulesPath ;
 adlRulesPathSegment  : ('/' | '//') adlRulesPathElement;
 adlRulesPathElement  : attribute_id ( '[' (ID_CODE | ARCHETYPE_REF) ']' )?;
 
 variableReference: SYM_VARIABLE_START identifier;
 
 plusMinusBinop: '+' | '-';
-mult_binop: '*' | '/' | '%';
+multBinop: '*' | '/' | '%';
 
 equalityBinop:
       '='

--- a/src/main/java/com/nedap/archie/adlparser/ADLParserErrors.java
+++ b/src/main/java/com/nedap/archie/adlparser/ADLParserErrors.java
@@ -53,6 +53,10 @@ public class ADLParserErrors {
         return this.getErrors().isEmpty() && this.getWarnings().isEmpty();
     }
 
+    public boolean hasNoErrors() {
+        return this.getErrors().isEmpty();
+    }
+
     public String toString() {
         StringBuilder result = new StringBuilder();
         append(result, "Warning", warnings);

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -1,7 +1,6 @@
 package com.nedap.archie.adlparser.treewalkers;
 
 import com.nedap.archie.adlparser.ADLParserErrors;
-import com.nedap.archie.adlparser.antlr.AdlParser;
 import com.nedap.archie.adlparser.antlr.AdlParser.*;
 
 import com.nedap.archie.aom.CPrimitiveObject;
@@ -24,138 +23,138 @@ public class RulesParser extends BaseTreeWalker {
     public RuleStatement parse(AssertionContext assertionContext) {
 
         Assertion assertion = new Assertion();
-        if(assertionContext.boolean_assertion() != null) {
-            Boolean_assertionContext context = assertionContext.boolean_assertion();
+        if(assertionContext.booleanAssertion() != null) {
+            BooleanAssertionContext context = assertionContext.booleanAssertion();
             assertion.setStringExpression(context.getText());//TODO: this has whitespace stripped. Get the Lexer input instead
             if (context.identifier() != null) {
                 assertion.setTag(context.identifier().getText());
             }
-            assertion.setExpression(parseExpression(context.boolean_expression()));
+            assertion.setExpression(parseExpression(context.booleanExpression()));
             return assertion;
-        } else if (assertionContext.variable_declaration() != null) {
-            VariableDeclaration declaration = parseVariableDeclaration(assertionContext.variable_declaration());
+        } else if (assertionContext.variableDeclaration() != null) {
+            VariableDeclaration declaration = parseVariableDeclaration(assertionContext.variableDeclaration());
             return declaration;
         }
         return assertion;
     }
 
-    private VariableDeclaration parseVariableDeclaration(Variable_declarationContext context) {
+    private VariableDeclaration parseVariableDeclaration(VariableDeclarationContext context) {
 
-        if(context.boolean_expression() != null) {
+        if(context.booleanExpression() != null) {
             ExpressionVariable result = new ExpressionVariable();
             setVariableNameAndType(context, result);
-            result.setExpression(parseExpression(context.boolean_expression()));
+            result.setExpression(parseExpression(context.booleanExpression()));
             return result;
 
-        } else if (context.arithmetic_expression() != null) {
+        } else if (context.plusExpression() != null) {
             ExpressionVariable result = new ExpressionVariable();
             setVariableNameAndType(context, result);
-            result.setExpression(parseArithmeticExpression(context.arithmetic_expression()));
+            result.setExpression(parseArithmeticExpression(context.plusExpression()));
             return result;
 
         }
         return null;
     }
 
-    private void setVariableNameAndType(AdlParser.Variable_declarationContext context, ExpressionVariable result) {
+    private void setVariableNameAndType(VariableDeclarationContext context, ExpressionVariable result) {
         result.setName(context.identifier(0).getText());
         result.setType(ExpressionType.fromString(context.identifier(1).getText()));
     }
 
-    private Expression parseExpression(Boolean_expressionContext context) {
+    private Expression parseExpression(BooleanExpressionContext context) {
 
         if(context.SYM_IMPLIES() != null) {
             BinaryOperator expression = new BinaryOperator();
             expression.setType(ExpressionType.BOOLEAN);
             expression.setOperator(OperatorKind.parse(context.SYM_IMPLIES().getText()));
-            expression.addOperand(parseExpression(context.boolean_expression()));
-            expression.addOperand(parseForAllExpression(context.boolean_for_all_expression()));
+            expression.addOperand(parseExpression(context.booleanExpression()));
+            expression.addOperand(parseForAllExpression(context.booleanForAllExpression()));
             return expression;
         } else {
-            return parseForAllExpression(context.boolean_for_all_expression());
+            return parseForAllExpression(context.booleanForAllExpression());
         }
 
     }
 
-    private Expression parseForAllExpression(Boolean_for_all_expressionContext context) {
+    private Expression parseForAllExpression(BooleanForAllExpressionContext context) {
         if(context.SYM_FOR_ALL() != null) {
 
             Expression pathExpression = null;
 
-            if (context.adl_rules_path() != null) {
-                pathExpression = parseModelReference(context.adl_rules_path());
+            if (context.adlRulesPath() != null) {
+                pathExpression = parseModelReference(context.adlRulesPath());
             } else {
-                pathExpression = parseVariableReference(context.variable_reference());
+                pathExpression = parseVariableReference(context.variableReference());
             }
             String variableName = context.identifier().getText();
             return new ForAllStatement(variableName,
                     pathExpression,
-                    parseForAllExpression(context.boolean_for_all_expression()));
+                    parseForAllExpression(context.booleanForAllExpression()));
         } else {
-            return parseOrExpression(context.boolean_or_expression());
+            return parseOrExpression(context.booleanOrExpression());
         }
 
     }
 
-    private Expression parseOrExpression(Boolean_or_expressionContext context) {
+    private Expression parseOrExpression(BooleanOrExpressionContext context) {
         if(context.SYM_OR() != null) {
             BinaryOperator expression = new BinaryOperator();
             expression.setType(ExpressionType.BOOLEAN);
             expression.setOperator(OperatorKind.parse(context.SYM_OR().getText()));
-            expression.addOperand(parseOrExpression(context.boolean_or_expression()));
-            expression.addOperand(parseAndExpression(context.boolean_and_expression()));
+            expression.addOperand(parseOrExpression(context.booleanOrExpression()));
+            expression.addOperand(parseAndExpression(context.booleanAndExpression()));
             return expression;
         } else {
-            return parseAndExpression(context.boolean_and_expression());
+            return parseAndExpression(context.booleanAndExpression());
         }
     }
 
-    private Expression parseAndExpression(Boolean_and_expressionContext context) {
+    private Expression parseAndExpression(BooleanAndExpressionContext context) {
         if(context.SYM_AND() != null) {
             BinaryOperator expression = new BinaryOperator();
             expression.setType(ExpressionType.BOOLEAN);
             expression.setOperator(OperatorKind.parse(context.SYM_AND().getText()));
-            expression.addOperand(parseAndExpression(context.boolean_and_expression()));
-            expression.addOperand(parseXorExpression(context.boolean_xor_expression()));
+            expression.addOperand(parseAndExpression(context.booleanAndExpression()));
+            expression.addOperand(parseXorExpression(context.booleanXorExpression()));
             return expression;
         } else {
-            return parseXorExpression(context.boolean_xor_expression());
+            return parseXorExpression(context.booleanXorExpression());
         }
     }
 
-    private Expression parseXorExpression(Boolean_xor_expressionContext context) {
+    private Expression parseXorExpression(BooleanXorExpressionContext context) {
         if(context.SYM_XOR() != null) {
             BinaryOperator expression = new BinaryOperator();
             expression.setType(ExpressionType.BOOLEAN);
             expression.setOperator(OperatorKind.parse(context.SYM_XOR().getText()));
-            expression.addOperand(parseBooleanConstraintExpression(context.boolean_constraint_expression()));
-            expression.addOperand(parseXorExpression(context.boolean_xor_expression()));
+            expression.addOperand(parseBooleanConstraintExpression(context.booleanConstraintExpression()));
+            expression.addOperand(parseXorExpression(context.booleanXorExpression()));
             return expression;
         } else {
-            return parseBooleanConstraintExpression(context.boolean_constraint_expression());
+            return parseBooleanConstraintExpression(context.booleanConstraintExpression());
         }
     }
 
-    private Expression parseBooleanConstraintExpression(Boolean_constraint_expressionContext context) {
-        if(context.boolean_constraint() != null) {
-            return parseBooleanConstraint(context.boolean_constraint());
+    private Expression parseBooleanConstraintExpression(BooleanConstraintExpressionContext context) {
+        if(context.booleanConstraint() != null) {
+            return parseBooleanConstraint(context.booleanConstraint());
         } else {
-            return parseArithmeticRelOpExpression(context.arithmetic_relop_expr());
+            return parseEqualityExpression(context.equalityExpression());
         }
     }
 
-    private Expression parseBooleanLiteral(Boolean_literalContext context) {
+    private Expression parseBooleanLiteral(BooleanLiteralContext context) {
         return new Constant<Boolean>(ExpressionType.BOOLEAN, context.SYM_TRUE() != null ? true : false);
     }
 
     @NotNull
-    private ModelReference parseModelReference(Adl_rules_pathContext context) {
+    private ModelReference parseModelReference(AdlRulesPathContext context) {
         String variableReference = null;
-        if(context.variable_reference() != null) {
-            variableReference = context.variable_reference().identifier().getText();
+        if(context.variableReference() != null) {
+            variableReference = context.variableReference().identifier().getText();
         }
         StringBuilder path = new StringBuilder();
-        for(Adl_rules_path_segmentContext pathSegment:context.adl_rules_path_segment()){
+        for(AdlRulesPathSegmentContext pathSegment:context.adlRulesPathSegment()){
             path.append(pathSegment.getText());
 
         }
@@ -163,17 +162,17 @@ public class RulesParser extends BaseTreeWalker {
     }
 
     @NotNull
-    private ModelReference parseModelReference(Adl_rules_relative_pathContext context) {
+    private ModelReference parseModelReference(AdlRulesRelativePathContext context) {
         return new ModelReference(context.getText());
     }
 
-    private Expression parseBooleanConstraint(Boolean_constraintContext context) {
+    private Expression parseBooleanConstraint(BooleanConstraintContext context) {
         ModelReference modelReference = null;
-        if(context.adl_rules_path() != null) {
-            modelReference = parseModelReference(context.adl_rules_path());
+        if(context.adlRulesPath() != null) {
+            modelReference = parseModelReference(context.adlRulesPath());
         }
-        if(context.adl_rules_relative_path() != null) {
-            modelReference = parseModelReference(context.adl_rules_relative_path());
+        if(context.adlRulesRelativePath() != null) {
+            modelReference = parseModelReference(context.adlRulesRelativePath());
         }
         CPrimitiveObject cPrimitiveObject = null;
         if(context.c_primitive_object() != null) {
@@ -184,67 +183,80 @@ public class RulesParser extends BaseTreeWalker {
         return new BinaryOperator(ExpressionType.BOOLEAN, OperatorKind.matches, modelReference, new Constraint(cPrimitiveObject));
     }
 
-    private Expression parseArithmeticRelOpExpression(Arithmetic_relop_exprContext context) {
-        if(context.relational_binop() != null) {
-            Expression left = parseArithmeticRelOpExpression(context.arithmetic_relop_expr());
-            Expression right = parseArithmeticExpression(context.arithmetic_expression());
+    private Expression parseEqualityExpression(EqualityExpressionContext context) {
+        if(context.equalityBinop() != null) {
+            Expression left = parseEqualityExpression(context.equalityExpression());
+            Expression right = parseArithmeticRelOpExpression(context.relOpExpression());
             if(left.getType() != null && right.getType() != null && left.getType() != right.getType()) {
                 throw new IllegalArgumentException("arithmetic relop expression with different types: " + left.getType() + " + " + right.getType());
             }
-            return new BinaryOperator(left.getType(), OperatorKind.parse(context.relational_binop().getText()), left, right);
+            return new BinaryOperator(left.getType(), OperatorKind.parse(context.equalityBinop().getText()), left, right);
         } else {
-            return parseArithmeticExpression(context.arithmetic_expression());
+            return parseArithmeticRelOpExpression(context.relOpExpression());
+        }
+    }
+
+    private Expression parseArithmeticRelOpExpression(RelOpExpressionContext context) {
+        if(context.relationalBinop() != null) {
+            Expression left = parseArithmeticRelOpExpression(context.relOpExpression());
+            Expression right = parseArithmeticExpression(context.plusExpression());
+            if(left.getType() != null && right.getType() != null && left.getType() != right.getType()) {
+                throw new IllegalArgumentException("arithmetic relop expression with different types: " + left.getType() + " + " + right.getType());
+            }
+            return new BinaryOperator(left.getType(), OperatorKind.parse(context.relationalBinop().getText()), left, right);
+        } else {
+            return parseArithmeticExpression(context.plusExpression());
         }
 
     }
 
-    private Expression parseArithmeticExpression(Arithmetic_expressionContext context) {
-        if(context.plus_minus_binop() != null) {
-            Expression left = parseArithmeticExpression(context.arithmetic_expression());
-            Expression right = parseMultiplyingExpression(context.multiplying_expression());
-            return new BinaryOperator(right.getType(), OperatorKind.parse(context.plus_minus_binop().getText()), left, right);
+    private Expression parseArithmeticExpression(PlusExpressionContext context) {
+        if(context.plusMinusBinop() != null) {
+            Expression left = parseArithmeticExpression(context.plusExpression());
+            Expression right = parseMultiplyingExpression(context.multiplyingExpression());
+            return new BinaryOperator(right.getType(), OperatorKind.parse(context.plusMinusBinop().getText()), left, right);
         } else {
-            return parseMultiplyingExpression(context.multiplying_expression());
+            return parseMultiplyingExpression(context.multiplyingExpression());
         }
     }
 
-    private Expression parseMultiplyingExpression(Multiplying_expressionContext context) {
+    private Expression parseMultiplyingExpression(MultiplyingExpressionContext context) {
         if(context.mult_binop() != null) {
-            Expression left = parseMultiplyingExpression(context.multiplying_expression());
-            Expression right = parsePowExpression(context.pow_expression());
+            Expression left = parseMultiplyingExpression(context.multiplyingExpression());
+            Expression right = parsePowExpression(context.powExpression());
             return new BinaryOperator(right.getType(), OperatorKind.parse(context.mult_binop().getText()), left, right);
         } else {
-            return parsePowExpression(context.pow_expression());
+            return parsePowExpression(context.powExpression());
         }
     }
 
-    private Expression parsePowExpression(Pow_expressionContext context) {
-        if(context.pow_expression() != null) {
-            Expression left = parsePowExpression(context.pow_expression());
-            Expression right = parseArithmeticLeaf(context.arithmetic_leaf());
+    private Expression parsePowExpression(PowExpressionContext context) {
+        if(context.powExpression() != null) {
+            Expression left = parsePowExpression(context.powExpression());
+            Expression right = parseArithmeticLeaf(context.expressionLeaf());
             return new BinaryOperator(right.getType(), OperatorKind.parse("^"), left, right);
         } else {
-            return parseArithmeticLeaf(context.arithmetic_leaf());
+            return parseArithmeticLeaf(context.expressionLeaf());
         }
     }
 
-    private Expression parseArithmeticLeaf(Arithmetic_leafContext context) {
+    private Expression parseArithmeticLeaf(ExpressionLeafContext context) {
         if(context.integer_value() != null) {
             return new Constant<>(ExpressionType.INTEGER, Long.parseLong(context.integer_value().getText()));
         }
         if(context.real_value() != null) {
             return new Constant<>(ExpressionType.REAL, Double.parseDouble(context.real_value().getText()));
         }
-        if(context.adl_rules_path() != null) {
-            ModelReference reference = parseModelReference(context.adl_rules_path());
+        if(context.adlRulesPath() != null) {
+            ModelReference reference = parseModelReference(context.adlRulesPath());
             if(context.SYM_EXISTS() != null) {
                 return new UnaryOperator(ExpressionType.BOOLEAN, OperatorKind.exists, reference);
             } else {
                 return reference;
             }
         }
-        if(context.boolean_expression() != null) {
-            Expression expression = this.parseExpression(context.boolean_expression());
+        if(context.booleanExpression() != null) {
+            Expression expression = this.parseExpression(context.booleanExpression());
             if(context.SYM_NOT() != null) {
                 return new UnaryOperator(ExpressionType.BOOLEAN, OperatorKind.not, expression);
             } else { //'this is '(' boolean_expression ')'
@@ -252,23 +264,23 @@ public class RulesParser extends BaseTreeWalker {
                 return expression;
             }
         }
-        if(context.arithmetic_leaf() != null) { // - arithmetic expression
-            return new UnaryOperator(ExpressionType.REAL, OperatorKind.minus, parseArithmeticLeaf(context.arithmetic_leaf()));
+        if(context.expressionLeaf() != null) { // - arithmetic expression
+            return new UnaryOperator(ExpressionType.REAL, OperatorKind.minus, parseArithmeticLeaf(context.expressionLeaf()));
         }
-        if(context.variable_reference() != null) {
-            return parseVariableReference(context.variable_reference());
+        if(context.variableReference() != null) {
+            return parseVariableReference(context.variableReference());
         }
-        if(context.boolean_literal() != null) {
-            return parseBooleanLiteral(context.boolean_literal());
+        if(context.booleanLiteral() != null) {
+            return parseBooleanLiteral(context.booleanLiteral());
         }
-        if(context.variable_reference() != null) {
-            return parseVariableReference(context.variable_reference());
+        if(context.variableReference() != null) {
+            return parseVariableReference(context.variableReference());
         }
         throw new IllegalArgumentException("cannot parse unknown arithmetic leaf type: " + context.getText());
     }
 
     @NotNull
-    private Expression parseVariableReference(Variable_referenceContext context) {
+    private Expression parseVariableReference(VariableReferenceContext context) {
         VariableReference reference = new VariableReference();
         //TODO: retrieve declaration from actual declaration, instead of just setting the name
         VariableDeclaration declaration = new VariableDeclaration();

--- a/src/main/java/com/nedap/archie/json/DateDeserializer.java
+++ b/src/main/java/com/nedap/archie/json/DateDeserializer.java
@@ -17,6 +17,9 @@ public class DateDeserializer extends JsonDeserializer<Temporal> {
     @Override
     public Temporal deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         String valueAsString = p.getValueAsString();
+        if(valueAsString == null) {
+            return null;
+        }
         return TemporalConstraintParser.parseDateValue(valueAsString);
     }
 }

--- a/src/main/java/com/nedap/archie/json/DateTimeDeserializer.java
+++ b/src/main/java/com/nedap/archie/json/DateTimeDeserializer.java
@@ -21,6 +21,9 @@ public class DateTimeDeserializer extends JsonDeserializer<TemporalAccessor>{
     @Override
     public TemporalAccessor deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         String valueAsString = p.getValueAsString();
+        if(valueAsString == null) {
+            return null;
+        }
         return TemporalConstraintParser.parseDateTimeValue(valueAsString);
     }
 

--- a/src/main/java/com/nedap/archie/json/DurationDeserializer.java
+++ b/src/main/java/com/nedap/archie/json/DurationDeserializer.java
@@ -16,6 +16,9 @@ public class DurationDeserializer extends JsonDeserializer<TemporalAmount> {
     @Override
     public TemporalAmount deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         String valueAsString = p.getValueAsString();
+        if(valueAsString == null) {
+            return null;
+        }
         return TemporalConstraintParser.parseDurationValue(valueAsString);
     }
 }

--- a/src/main/java/com/nedap/archie/json/TimeDeserializer.java
+++ b/src/main/java/com/nedap/archie/json/TimeDeserializer.java
@@ -16,6 +16,9 @@ public class TimeDeserializer extends JsonDeserializer<TemporalAccessor> {
     @Override
     public TemporalAccessor deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         String valueAsString = p.getValueAsString();
+        if(valueAsString == null) {
+            return null;
+        }
         return TemporalConstraintParser.parseTimeValue(valueAsString);
     }
 }

--- a/src/main/java/com/nedap/archie/rules/OperatorKind.java
+++ b/src/main/java/com/nedap/archie/rules/OperatorKind.java
@@ -8,7 +8,7 @@ import java.util.Set;
  * Created by pieter.bos on 27/10/15.
  */
 public enum OperatorKind {
-    eq("="), ne("!=", "≠"), le("<", "≤"), lt("<="), ge(">=", "≥"), gt(">"),
+    eq("="), ne("!=", "≠"), le("<=", "≤"), lt("<"), ge(">=", "≥"), gt(">"),
     matches("matches", "∈", "is_in"), not("not", "!", "∼", "¬"), and("and", "∧"), or("or", "∨"), xor("xor", "⊻"),
     implies("implies", "⇒"), for_all("for_all", "∀", "every"), exists("exists" ,"∃"),
     plus("+"), minus("-"), multiply("*"), divide("/"), modulo("%"), exponent("^");

--- a/src/main/java/com/nedap/archie/rules/evaluation/ValueList.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/ValueList.java
@@ -116,14 +116,13 @@ public class ValueList {
     }
 
     public boolean isEmpty() {
-
+        boolean containsValue = false;
         for(Value value:this.values) {
-            if(value.isNull()) {
-                logger.warn("value null:", value);
-                logger.warn("other values: ", this.values);
+            if(!value.isNull()) {
+                containsValue = true;
             }
         }
-        return values.isEmpty();
+        return !containsValue;
     }
 
     public void addValues(ValueList evaluated) {

--- a/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -3,7 +3,6 @@ package com.nedap.archie.rules.evaluation.evaluators;
 import com.google.common.collect.Lists;
 import com.nedap.archie.rules.BinaryOperator;
 import com.nedap.archie.rules.Constraint;
-import com.nedap.archie.rules.Operator;
 import com.nedap.archie.rules.OperatorKind;
 import com.nedap.archie.rules.PrimitiveType;
 import com.nedap.archie.rules.evaluation.Evaluator;
@@ -272,7 +271,7 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
             possibleNullResult.setType(PrimitiveType.Boolean);
             return possibleNullResult;
         } else if(leftValues.getType() == PrimitiveType.Boolean || rightValues.getType() == PrimitiveType.Boolean) {
-            //TODO: check types
+            //TODO: check types and throw error when one of the types is not either boolean or null
             if(!EnumSet.of(OperatorKind.eq, OperatorKind.ne).contains(statement.getOperator()) ) {
                 throw new IllegalStateException("Operator " + statement.getOperator().toString() + " not valid for boolean type");
             }

--- a/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -59,7 +59,7 @@ public class ParsedRulesEvaluationTest {
     @Test
     public void simpleArithmetic() throws Exception {
         archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("simplearithmetic.adls"));
-        assertTrue(parser.getErrors().hasNoMessages());
+        assertTrue(parser.getErrors().hasNoErrors());
         RuleEvaluation ruleEvaluation = new RuleEvaluation(archetype);
         Observation root = new Observation();
         ruleEvaluation.evaluate(root, archetype.getRules().getRules());

--- a/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -292,6 +292,42 @@ public class ParsedRulesEvaluationTest {
         assertEquals(20.0d, (Double) evaluationResult.getSetPathValues().values().iterator().next().getValue(), 0.0001d);
     }
 
+    @Test
+    public void calculatedPathValuesWithNulls1() throws Exception {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("calculated_path_values.adls"));
+        RuleEvaluation ruleEvaluation = new RuleEvaluation(archetype);
+
+        Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        DvQuantity systolic = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value[id13]");
+        systolic.setMagnitude(80d);
+        DvQuantity diastolic = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value[id14]");
+        diastolic.setMagnitude(null);
+
+        EvaluationResult evaluationResult = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+        assertEquals(1, evaluationResult.getAssertionResults().size());
+        assertFalse(evaluationResult.getAssertionResults().get(0).getResult());
+        assertEquals(1, evaluationResult.getSetPathValues().size());
+        assertEquals(null, evaluationResult.getSetPathValues().values().iterator().next().getValue());
+    }
+
+    @Test
+    public void calculatedPathValuesWithNulls2() throws Exception {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("calculated_path_values.adls"));
+        RuleEvaluation ruleEvaluation = new RuleEvaluation(archetype);
+
+        Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        DvQuantity systolic = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value[id13]");
+        systolic.setMagnitude(null);
+        DvQuantity diastolic = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value[id14]");
+        diastolic.setMagnitude(80d);
+
+        EvaluationResult evaluationResult = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+        assertEquals(1, evaluationResult.getAssertionResults().size());
+        assertFalse(evaluationResult.getAssertionResults().get(0).getResult());
+        assertEquals(1, evaluationResult.getSetPathValues().size());
+        assertEquals(null, evaluationResult.getSetPathValues().values().iterator().next().getValue());
+    }
+
     /**
      * Calculate a path value, then use that calculated path value in another rule to calculate more
      * Tests that calculated values are immediately set in the RMObject for further calculation correctly

--- a/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -487,5 +487,20 @@ public class ParsedRulesEvaluationTest {
 
     }
 
+    @Test
+    public void booleanOperandRelOps() throws Exception {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("boolean_operand_relops.adls"));
+        assertTrue(parser.getErrors().hasNoErrors());
+        RuleEvaluation ruleEvaluation = new RuleEvaluation(archetype);
+        Observation root = new Observation();
+        ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+        VariableMap variables = ruleEvaluation.getVariableMap();
+        assertEquals(true, variables.get("false_is_not_true").getObject(0));
+        assertEquals(true, variables.get("false_is_false").getObject(0));
+        assertEquals(false, variables.get("false_is_true").getObject(0));
+        assertEquals(true, variables.get("arithmetic_boolean_operands_true").getObject(0));
+        assertEquals(false, variables.get("arithmetic_boolean_operands_false").getObject(0));
+    }
+
 
 }

--- a/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -4,6 +4,7 @@ import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.rm.archetyped.Pathable;
 import com.nedap.archie.rm.composition.Observation;
+import com.nedap.archie.rm.datastructures.Element;
 import com.nedap.archie.rm.datavalues.quantity.DvQuantity;
 import com.nedap.archie.rules.Assertion;
 import com.nedap.archie.rules.BinaryOperator;
@@ -320,6 +321,26 @@ public class ParsedRulesEvaluationTest {
         systolic.setMagnitude(null);
         DvQuantity diastolic = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value[id14]");
         diastolic.setMagnitude(80d);
+
+        EvaluationResult evaluationResult = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+        assertEquals(1, evaluationResult.getAssertionResults().size());
+        assertFalse(evaluationResult.getAssertionResults().get(0).getResult());
+        assertEquals(1, evaluationResult.getSetPathValues().size());
+        assertEquals(null, evaluationResult.getSetPathValues().values().iterator().next().getValue());
+    }
+
+    @Test
+    public void calculatedPathValuesWithNulls3() throws Exception {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("extended_calculated_path_values.adls"));
+        RuleEvaluation ruleEvaluation = new RuleEvaluation(archetype);
+
+        Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        Element systolic = (Element) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]");
+        systolic.setValue(null);
+        Element diastolic = (Element) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]");
+        diastolic.setValue(null);
+        DvQuantity value3 = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value");
+        value3.setMagnitude(80d);
 
         EvaluationResult evaluationResult = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
         assertEquals(1, evaluationResult.getAssertionResults().size());

--- a/src/test/resources/com/nedap/archie/rules/evaluation/boolean_operand_relops.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/boolean_operand_relops.adls
@@ -1,0 +1,44 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+	openEHR-EHR-OBSERVATION.boolean_relops.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Test for rules, simple constant arithmetics">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+	OBSERVATION[id1]
+
+rules
+	$false_is_not_true:Boolean ::= false != true;
+    $false_is_false:Boolean ::= false = false;
+    $false_is_true:Boolean ::= false = true;
+    $true_is_false:Boolean ::= true = false;
+    $arithmetic_boolean_operands_true:Boolean ::= 1 > 3 = 5 > 8;
+    $arithmetic_boolean_operands_false:Boolean ::= 1 < 3 = 5 > 8;
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Blood Pressure">
+				description = <"The local measurement of arterial blood pressure which is a surrogate for arterial. pressure in the systemic circulation.  Most commonly, use of the term 'blood pressure' refers to measurement of brachial artery pressure in the upper arm.">
+			>
+		>
+    >
+

--- a/src/test/resources/com/nedap/archie/rules/evaluation/extended_calculated_path_values.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/extended_calculated_path_values.adls
@@ -1,0 +1,94 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+	openEHR-EHR-OBSERVATION.multiplicity.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Test for rules, simple constant arithmetics">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+	OBSERVATION[id1] matches {	-- Body mass index
+		data matches {
+			HISTORY[id2] matches {
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[id3] occurrences matches {1..*} matches {	-- Any event
+						data matches {
+							ITEM_TREE[id4] matches {
+								items cardinality matches {3; unordered} matches {
+									ELEMENT[id5] matches {	-- systolic pressure
+										value matches {
+											DV_QUANTITY[id13] matches {
+												[magnitude, units, precision] matches {
+													[{|0.0..<1000.0|}, {"mmHg"}, {1}]
+												}
+											}
+										}
+									}
+									ELEMENT[id6] matches {	-- diastolic pressure
+                                        value matches {
+                                            DV_QUANTITY[id14] matches {
+                                                [magnitude, units, precision] matches {
+                                                    [{|0.0..<1000.0|}, {"mmHg"}, {1}]
+                                                }
+                                            }
+                                        }
+                                    }
+                                    ELEMENT[id7] matches {	-- difference between systolic and diastolic. For testing purposes :)
+                                        value matches {
+                                            DV_QUANTITY[id15] matches {
+                                                [magnitude, units, precision] matches {
+                                                    [{|0.0..<1000.0|}, {"mmHg"}, {1}]
+                                                }
+                                            }
+                                        }
+                                    }
+                                    ELEMENT[id8] matches {	-- sum of other fields
+                                        value matches {
+                                            DV_QUANTITY[id16] matches {
+                                                [magnitude, units, precision] matches {
+                                                    [{|0.0..<1000.0|}, {"mmHg"}, {1}]
+                                                }
+                                            }
+                                        }
+                                    }
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+rules
+	/data[id2]/events[id3]/data[id4]/items[id8]/value/magnitude = /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
+	    + /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
+	    + /data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude;
+
+
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Blood Pressure">
+				description = <"The local measurement of arterial blood pressure which is a surrogate for arterial. pressure in the systemic circulation.  Most commonly, use of the term 'blood pressure' refers to measurement of brachial artery pressure in the upper arm.">
+			>
+		>
+    >
+


### PR DESCRIPTION
Lots of fixes:
- refactored grammar so we can do 'true = false' and it will evaluate to false instead of being a syntax error. This also prepares it for other types like string operations
- The < and <= operator did <= and < respectively
- Added == and != operator precedence to make 1 < 2 = 3 < 5 evaluate to true without parentheses
- Refactored the rules grammar to camelCase instead of snake_case because that's the ANTLR convention and snake_case produces very ugly looking java code.
