### PR TITLE
Paths in lexer

### DIFF
--- a/src/main/antlr/adl_rules.g4
+++ b/src/main/antlr/adl_rules.g4
@@ -56,7 +56,7 @@ booleanConstraintExpression
     | equalityExpression;
 
 
-booleanConstraint: ( adlRulesPath | adlRulesRelativePath ) SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
+booleanConstraint: adlRulesPath SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
 
 equalityExpression:
     relOpExpression
@@ -107,10 +107,7 @@ argumentList:
 functionName:
     identifier;
 
-adlRulesPath          : variableReference? adlRulesPathSegment+;
-adlRulesRelativePath : adlRulesPathElement adlRulesPath ;
-adlRulesPathSegment  : ('/' | '//') adlRulesPathElement;
-adlRulesPathElement  : attribute_id ( '[' (ID_CODE | ARCHETYPE_REF) ']' )?;
+adlRulesPath          : SYM_VARIABLE_START? ADL_PATH;
 
 variableReference: SYM_VARIABLE_START identifier;
 

--- a/src/main/antlr/adl_rules.g4
+++ b/src/main/antlr/adl_rules.g4
@@ -14,22 +14,22 @@ import cadl_primitives;
 //  ============== Parser rules ==============
 //
 
-assertion_list: (assertion (';'))+ ;// {_input.LA(1) == WS || _input.LA(1) == LINE}?) +;//whitespace parsing to prevent ambiguity
+assertion_list: (assertion (';')?)+ ;// {_input.LA(1) == WS || _input.LA(1) == LINE}?) +;//whitespace parsing to prevent ambiguity
 
 assertion: variableDeclaration | booleanAssertion;
 
-variableDeclaration: SYM_VARIABLE_START identifier SYM_COLON identifier SYM_ASSIGNMENT (booleanExpression | plusExpression);
+variableDeclaration: SYM_VARIABLE_START identifier SYM_COLON identifier SYM_ASSIGNMENT expression;
 
-booleanAssertion: ( identifier SYM_COLON )? booleanExpression ;
+booleanAssertion: ( identifier SYM_COLON )? expression ;
 
 //
 // Expressions evaluating to boolean values
 //
 
 
-booleanExpression
+expression
     : booleanForAllExpression
-    | booleanExpression SYM_IMPLIES booleanForAllExpression
+    | expression SYM_IMPLIES booleanForAllExpression
     ;
 
 booleanForAllExpression
@@ -93,11 +93,19 @@ expressionLeaf:
     | string_value
     | adlRulesPath
     | SYM_EXISTS adlRulesPath
-    | SYM_NOT booleanExpression
+    | SYM_NOT expression
+    | functionName '(' (argumentList)? ')'
     | variableReference
-    | '(' booleanExpression ')'
+    | '(' expression ')'
     | '-' expressionLeaf
     ;
+
+argumentList:
+    expression (',' expression)*
+    ;
+
+functionName:
+    identifier;
 
 adlRulesPath          : variableReference? adlRulesPathSegment+;
 adlRulesRelativePath : adlRulesPathElement adlRulesPath ;

--- a/src/main/antlr/adl_rules.g4
+++ b/src/main/antlr/adl_rules.g4
@@ -22,6 +22,8 @@ variableDeclaration: SYM_VARIABLE_START identifier SYM_COLON identifier SYM_ASSI
 
 booleanAssertion: ( identifier SYM_COLON )? expression ;
 
+
+
 //
 // Expressions evaluating to boolean values
 //
@@ -63,31 +65,23 @@ equalityExpression:
     | equalityExpression equalityBinop relOpExpression ;
 
 relOpExpression:
-    plusExpression
-    | relOpExpression relationalBinop plusExpression ;
+    arithmeticExpression
+    | relOpExpression relationalBinop arithmeticExpression ;
 
 
 //
 // Expressions evaluating to all kinds of value types
 //
 
-plusExpression
-   : multiplyingExpression
-   | plusExpression plusMinusBinop multiplyingExpression
+arithmeticExpression
+   : <assoc=right> arithmeticExpression powBinop arithmeticExpression
+   | arithmeticExpression multBinop arithmeticExpression
+   | arithmeticExpression plusMinusBinop arithmeticExpression
+   | expressionLeaf
    ;
 
-multiplyingExpression
-   : powExpression
-   | multiplyingExpression multBinop powExpression
-   ;
-
-powExpression
-   : expressionLeaf
-   | <assoc=right> powExpression '^' expressionLeaf
-   ;
-
-expressionLeaf:
-      booleanLiteral
+expressionLeaf
+    : booleanLiteral
     | integer_value
     | real_value
     | string_value
@@ -113,26 +107,27 @@ variableReference: SYM_VARIABLE_START identifier;
 
 plusMinusBinop: '+' | '-';
 multBinop: '*' | '/' | '%';
+powBinop: '^';
 
-equalityBinop:
-      '='
+equalityBinop
+    : '='
     | '!='
     ;
 
-relationalBinop:
-    | '<='
+relationalBinop
+    : '<='
     | '<'
     | '>='
     | '>'
     ;
 
-booleanLiteral:
-      SYM_TRUE
+booleanLiteral
+    : SYM_TRUE
     | SYM_FALSE
     ;
 
-SYM_FOR_ALL:
-    'for_all'
+SYM_FOR_ALL
+    : 'for_all'
     | '∀'
     | 'every' //if we follow xpath syntax, let's do that here as well (xpath 2 and xpath 3)
     ;

--- a/src/main/antlr/base_patterns.g4
+++ b/src/main/antlr/base_patterns.g4
@@ -8,6 +8,25 @@ grammar base_patterns;
 // -------------------------- Parse Rules --------------------------
 //
 
+ADL_PATH          : ADL_ABSOLUTE_PATH | ADL_RELATIVE_PATH;
+fragment ADL_ABSOLUTE_PATH : ('/' PATH_SEGMENT)+;
+fragment ADL_RELATIVE_PATH : PATH_SEGMENT ('/' PATH_SEGMENT)+;
+
+fragment PATH_SEGMENT      : ALPHA_LC_ID ('[' PATH_ATTRIBUTE ']')?;
+fragment PATH_ATTRIBUTE    : ID_CODE | STRING | INTEGER | ARCHETYPE_REF;
+
+//
+//  ======================= Lexical rules ========================
+//
+
+// ---------- various ADL2 codes -------
+
+ROOT_ID_CODE : 'id1' '.1'* ;
+ID_CODE      : 'id' CODE_STR ;
+AT_CODE      : 'at' CODE_STR ;
+AC_CODE      : 'ac' CODE_STR ;
+fragment CODE_STR : ('0' | [1-9][0-9]*) ( '.' ('0' | [1-9][0-9]* ))* ;
+
 type_id      : ALPHA_UC_ID ( '<' type_id ( ',' type_id )* '>' )? ;
 attribute_id : ALPHA_LC_ID ;
 identifier   : ALPHA_UC_ID | ALPHA_LC_ID ;

--- a/src/main/antlr/cadl.g4
+++ b/src/main/antlr/cadl.g4
@@ -48,9 +48,7 @@ c_attribute_def:
     | c_attribute_tuple
     ;
 
-c_attribute: adl_dir? attribute_id c_existence? c_cardinality? ( SYM_MATCHES ('{' c_objects '}' | CONTAINED_REGEXP) )? ;
-
-adl_dir  : '/' | ( adl_path_segment+ '/' ) ;
+c_attribute: (ADL_PATH | attribute_id) c_existence? c_cardinality? ( SYM_MATCHES ('{' c_objects '}' | CONTAINED_REGEXP) )? ;
 
 c_attribute_tuple : '[' attribute_id ( ',' attribute_id )* ']' SYM_MATCHES '{' c_object_tuple ( ',' c_object_tuple )* '}' ;
 

--- a/src/main/antlr/cadl_primitives.g4
+++ b/src/main/antlr/cadl_primitives.g4
@@ -67,7 +67,7 @@ adl_path          : ADL_PATH;
 DATE_CONSTRAINT_PATTERN      : YEAR_PATTERN '-' MONTH_PATTERN '-' DAY_PATTERN ;
 TIME_CONSTRAINT_PATTERN      : HOUR_PATTERN SYM_COLON MINUTE_PATTERN SYM_COLON SECOND_PATTERN ;
 DATE_TIME_CONSTRAINT_PATTERN : DATE_CONSTRAINT_PATTERN 'T' TIME_CONSTRAINT_PATTERN ;
-DURATION_CONSTRAINT_PATTERN  : 'P' [yY]?[mM]?[Ww]?[dD]? ( 'T' [hH]?[mM]?[sS]? )? ('/')?; //TODO: can also be a list!
+DURATION_CONSTRAINT_PATTERN  : 'P' [yY]?[mM]?[Ww]?[dD]? ( 'T' [hH]?[mM]?[sS]? )? ('/')?;
 
 // date time pattern
 fragment YEAR_PATTERN   : ( 'yyy' 'y'? ) | ( 'YYY' 'Y'? ) ;

--- a/src/main/antlr/cadl_primitives.g4
+++ b/src/main/antlr/cadl_primitives.g4
@@ -60,24 +60,7 @@ assumed_boolean_value: ';' boolean_value ;
 
 adl_path          : ADL_PATH;
 
-ADL_PATH          : ADL_ABSOLUTE_PATH | ADL_RELATIVE_PATH;
-fragment ADL_ABSOLUTE_PATH : ('/' PATH_SEGMENT)+;
-fragment ADL_RELATIVE_PATH : PATH_SEGMENT ('/' PATH_SEGMENT)+;
 
-fragment PATH_SEGMENT      : ALPHA_LC_ID ('[' PATH_ATTRIBUTE ']')?;
-fragment PATH_ATTRIBUTE    : ID_CODE | STRING | INTEGER | ARCHETYPE_REF;
-
-//
-//  ======================= Lexical rules ========================
-//
-
-// ---------- various ADL2 codes -------
-
-ROOT_ID_CODE : 'id1' '.1'* ;
-ID_CODE      : 'id' CODE_STR ;
-AT_CODE      : 'at' CODE_STR ;
-AC_CODE      : 'ac' CODE_STR ;
-fragment CODE_STR : ('0' | [1-9][0-9]*) ( '.' ('0' | [1-9][0-9]* ))* ;
 
 // ---------- ISO8601-based date/time/duration constraint patterns
 

--- a/src/main/antlr/cadl_primitives.g4
+++ b/src/main/antlr/cadl_primitives.g4
@@ -41,7 +41,7 @@ c_time: ( TIME_CONSTRAINT_PATTERN | time_value | time_list_value | time_interval
 assumed_time_value: ';' time_value ;
 
 c_duration: (
-      DURATION_CONSTRAINT_PATTERN ( '/' ( duration_interval_value | duration_value ))?
+      DURATION_CONSTRAINT_PATTERN ( ( duration_interval_value | duration_value ))?
     | duration_value | duration_list_value | duration_interval_value | duration_interval_list_value ) assumed_duration_value?
     ;
 assumed_duration_value: ';' duration_value ;
@@ -58,11 +58,14 @@ c_terminology_code: '[' ( ( AC_CODE ( ';' AT_CODE )? ) | AT_CODE ) ']' ;
 c_boolean: ( boolean_value | boolean_list_value ) assumed_boolean_value? ;
 assumed_boolean_value: ';' boolean_value ;
 
-adl_path          : adl_path_segment+;//(adl_path_segment ({_input.LA(-1) != WS && _input.LA(-1) != LINE}?))+ adl_path_segment? ;
-adl_relative_path : adl_path_element adl_path ;  // TODO: remove when current slots no longer needed
-adl_path_segment  : SYM_SLASH adl_path_element ;
-adl_path_element  : attribute_id ( SYM_LEFT_BRACKET ID_CODE SYM_RIGHT_BRACKET )? ;
+adl_path          : ADL_PATH;
 
+ADL_PATH          : ADL_ABSOLUTE_PATH | ADL_RELATIVE_PATH;
+fragment ADL_ABSOLUTE_PATH : ('/' PATH_SEGMENT)+;
+fragment ADL_RELATIVE_PATH : PATH_SEGMENT ('/' PATH_SEGMENT)+;
+
+fragment PATH_SEGMENT      : ALPHA_LC_ID ('[' PATH_ATTRIBUTE ']')?;
+fragment PATH_ATTRIBUTE    : ID_CODE | STRING | INTEGER | ARCHETYPE_REF;
 
 //
 //  ======================= Lexical rules ========================
@@ -81,7 +84,7 @@ fragment CODE_STR : ('0' | [1-9][0-9]*) ( '.' ('0' | [1-9][0-9]* ))* ;
 DATE_CONSTRAINT_PATTERN      : YEAR_PATTERN '-' MONTH_PATTERN '-' DAY_PATTERN ;
 TIME_CONSTRAINT_PATTERN      : HOUR_PATTERN SYM_COLON MINUTE_PATTERN SYM_COLON SECOND_PATTERN ;
 DATE_TIME_CONSTRAINT_PATTERN : DATE_CONSTRAINT_PATTERN 'T' TIME_CONSTRAINT_PATTERN ;
-DURATION_CONSTRAINT_PATTERN  : 'P' [yY]?[mM]?[Ww]?[dD]? ( 'T' [hH]?[mM]?[sS]? )? ;
+DURATION_CONSTRAINT_PATTERN  : 'P' [yY]?[mM]?[Ww]?[dD]? ( 'T' [hH]?[mM]?[sS]? )? ('/')?; //TODO: can also be a list!
 
 // date time pattern
 fragment YEAR_PATTERN   : ( 'yyy' 'y'? ) | ( 'YYY' 'Y'? ) ;

--- a/src/main/antlr/odin.g4
+++ b/src/main/antlr/odin.g4
@@ -68,6 +68,4 @@ primitive_interval_value :
 object_reference_block : '<' odin_path_list '>' ;
 
 odin_path_list     : odin_path ( ( ',' odin_path )+ | SYM_LIST_CONTINUE )? ;
-odin_path          : '/' | odin_path_segment+ ;
-odin_path_segment  : '/' odin_path_element ;
-odin_path_element  : attribute_id ( '[' ( STRING | INTEGER ) ']' )? ;
+odin_path          : '/' | ADL_PATH ;

--- a/src/main/java/com/nedap/archie/adlparser/ADLParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/ADLParser.java
@@ -60,6 +60,7 @@ public class ADLParser {
         parser = new AdlParser(new CommonTokenStream(lexer));
         parser.addErrorListener(errorListener);
         tree = parser.adl(); // parse
+        //System.out.println(tree.toStringTree(parser));
 
         ADLListener listener = new ADLListener(errors);
         walker= new ParseTreeWalker();

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
@@ -61,12 +61,15 @@ public class CComplexObjectParser extends BaseTreeWalker {
         if (attributeDefContext.c_attribute() != null) {
             CAttribute attribute = new CAttribute();
             C_attributeContext attributeContext = attributeDefContext.c_attribute();
-            attribute.setRmAttributeName(attributeContext.attribute_id().getText());
+            if(attributeContext.attribute_id() != null) {
+                attribute.setRmAttributeName(attributeContext.attribute_id().getText());
+            } else {
+                attribute.setDifferentialPath(attributeContext.ADL_PATH().getText());
+
+                attribute.setRmAttributeName(getLastAttributeFromPath(attribute.getDifferentialPath()));
+            }
             if (attributeContext.c_existence() != null) {
                 attribute.setExistence(parseMultiplicityInterval(attributeContext.c_existence()));
-            }
-            if(attributeContext.adl_dir() != null) {
-                attribute.setDifferentialPath(attributeContext.adl_dir().getText() + attributeContext.attribute_id().getText());
             }
 
             if (attributeContext.c_cardinality() != null) {
@@ -82,6 +85,18 @@ public class CComplexObjectParser extends BaseTreeWalker {
             parent.addAttributeTuple(parseAttributeTuple(parent, attributeDefContext.c_attribute_tuple()));
         }
 
+    }
+
+    public static String getFirstAttributeOfPath(String path) {
+        return path.substring(0, path.indexOf('/'));
+    }
+
+    public static String getPathMinusFirstAttribute(String path) {
+        return path.substring(path.indexOf('/'));
+    }
+
+    public static String getLastAttributeFromPath(String path) {
+           return path.substring(path.lastIndexOf('/')+1);
     }
 
     private CAttributeTuple parseAttributeTuple(CComplexObject parent, C_attribute_tupleContext attributeTupleContext) {

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -183,46 +183,36 @@ public class RulesParser extends BaseTreeWalker {
     private Expression parseRelOpExpression(RelOpExpressionContext context) {
         if(context.relationalBinop() != null) {
             Expression left = parseRelOpExpression(context.relOpExpression());
-            Expression right = parsePlusExpression(context.plusExpression());
+            Expression right = parseArithmeticExpression(context.arithmeticExpression());
             if(left.getType() != null && right.getType() != null && left.getType() != right.getType()) {
                 throw new IllegalArgumentException("arithmetic relop expression with different types: " + left.getType() + " + " + right.getType());
             }
             return new BinaryOperator(left.getType(), OperatorKind.parse(context.relationalBinop().getText()), left, right);
         } else {
-            return parsePlusExpression(context.plusExpression());
+            return parseArithmeticExpression(context.arithmeticExpression());
         }
 
     }
 
-    private Expression parsePlusExpression(PlusExpressionContext context) {
+    private Expression parseArithmeticExpression(ArithmeticExpressionContext context) {
         if(context.plusMinusBinop() != null) {
-            Expression left = parsePlusExpression(context.plusExpression());
-            Expression right = parseMultiplyingExpression(context.multiplyingExpression());
+            Expression left = parseArithmeticExpression(context.arithmeticExpression().get(0));
+            Expression right = parseArithmeticExpression(context.arithmeticExpression().get(1));
             return new BinaryOperator(right.getType(), OperatorKind.parse(context.plusMinusBinop().getText()), left, right);
-        } else {
-            return parseMultiplyingExpression(context.multiplyingExpression());
-        }
-    }
-
-    private Expression parseMultiplyingExpression(MultiplyingExpressionContext context) {
-        if(context.multBinop() != null) {
-            Expression left = parseMultiplyingExpression(context.multiplyingExpression());
-            Expression right = parsePowExpression(context.powExpression());
+        } else if(context.multBinop() != null) {
+            Expression left = parseArithmeticExpression(context.arithmeticExpression().get(0));
+            Expression right = parseArithmeticExpression(context.arithmeticExpression().get(1));
             return new BinaryOperator(right.getType(), OperatorKind.parse(context.multBinop().getText()), left, right);
-        } else {
-            return parsePowExpression(context.powExpression());
-        }
-    }
-
-    private Expression parsePowExpression(PowExpressionContext context) {
-        if(context.powExpression() != null) {
-            Expression left = parsePowExpression(context.powExpression());
-            Expression right = parseExpressionLeaf(context.expressionLeaf());
-            return new BinaryOperator(right.getType(), OperatorKind.parse("^"), left, right);
-        } else {
+        } else if(context.powBinop() != null) {
+            Expression left = parseArithmeticExpression(context.arithmeticExpression().get(0));
+            Expression right = parseArithmeticExpression(context.arithmeticExpression().get(1));
+            return new BinaryOperator(right.getType(), OperatorKind.parse(context.powBinop().getText()), left, right);
+        }else {
             return parseExpressionLeaf(context.expressionLeaf());
         }
     }
+
+
 
     private Expression parseExpressionLeaf(ExpressionLeafContext context) {
         if(context.integer_value() != null) {

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -142,30 +142,22 @@ public class RulesParser extends BaseTreeWalker {
     @NotNull
     private ModelReference parseModelReference(AdlRulesPathContext context) {
         String variableReference = null;
-        if(context.variableReference() != null) {
-            variableReference = context.variableReference().identifier().getText();
+        String path = context.ADL_PATH().getText();
+        if(context.SYM_VARIABLE_START() != null) {
+            variableReference = CComplexObjectParser.getFirstAttributeOfPath(path);
+            path = CComplexObjectParser.getPathMinusFirstAttribute(path);
         }
-        StringBuilder path = new StringBuilder();
-        for(AdlRulesPathSegmentContext pathSegment:context.adlRulesPathSegment()){
-            path.append(pathSegment.getText());
 
-        }
-        return new ModelReference(variableReference, path.toString());
+        return new ModelReference(variableReference, path);
     }
 
-    @NotNull
-    private ModelReference parseModelReference(AdlRulesRelativePathContext context) {
-        return new ModelReference(context.getText());
-    }
 
     private Expression parseBooleanConstraint(BooleanConstraintContext context) {
         ModelReference modelReference = null;
         if(context.adlRulesPath() != null) {
             modelReference = parseModelReference(context.adlRulesPath());
         }
-        if(context.adlRulesRelativePath() != null) {
-            modelReference = parseModelReference(context.adlRulesRelativePath());
-        }
+
         CPrimitiveObject cPrimitiveObject = null;
         if(context.c_primitive_object() != null) {
             cPrimitiveObject = primitivesConstraintParser.parsePrimitiveObject(context.c_primitive_object());

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -31,7 +31,7 @@ public class RulesParser extends BaseTreeWalker {
             if (context.identifier() != null) {
                 assertion.setTag(context.identifier().getText());
             }
-            assertion.setExpression(parseExpression(context.booleanExpression()));
+            assertion.setExpression(parseExpression(context.expression()));
             return assertion;
         } else if (assertionContext.variableDeclaration() != null) {
             VariableDeclaration declaration = parseVariableDeclaration(assertionContext.variableDeclaration());
@@ -41,21 +41,11 @@ public class RulesParser extends BaseTreeWalker {
     }
 
     private VariableDeclaration parseVariableDeclaration(VariableDeclarationContext context) {
+        ExpressionVariable result = new ExpressionVariable();
+        setVariableNameAndType(context, result);
+        result.setExpression(parseExpression(context.expression()));
+        return result;
 
-        if(context.booleanExpression() != null) {
-            ExpressionVariable result = new ExpressionVariable();
-            setVariableNameAndType(context, result);
-            result.setExpression(parseExpression(context.booleanExpression()));
-            return result;
-
-        } else if (context.plusExpression() != null) {
-            ExpressionVariable result = new ExpressionVariable();
-            setVariableNameAndType(context, result);
-            result.setExpression(parsePlusExpression(context.plusExpression()));
-            return result;
-
-        }
-        return null;
     }
 
     private void setVariableNameAndType(VariableDeclarationContext context, ExpressionVariable result) {
@@ -63,13 +53,13 @@ public class RulesParser extends BaseTreeWalker {
         result.setType(ExpressionType.fromString(context.identifier(1).getText()));
     }
 
-    private Expression parseExpression(BooleanExpressionContext context) {
+    private Expression parseExpression(ExpressionContext context) {
 
         if(context.SYM_IMPLIES() != null) {
             BinaryOperator expression = new BinaryOperator();
             expression.setType(ExpressionType.BOOLEAN);
             expression.setOperator(OperatorKind.parse(context.SYM_IMPLIES().getText()));
-            expression.addOperand(parseExpression(context.booleanExpression()));
+            expression.addOperand(parseExpression(context.expression()));
             expression.addOperand(parseForAllExpression(context.booleanForAllExpression()));
             return expression;
         } else {
@@ -259,8 +249,8 @@ public class RulesParser extends BaseTreeWalker {
                 return reference;
             }
         }
-        else if(context.booleanExpression() != null) {
-            Expression expression = this.parseExpression(context.booleanExpression());
+        else if(context.expression() != null) {
+            Expression expression = this.parseExpression(context.expression());
             if(context.SYM_NOT() != null) {
                 return new UnaryOperator(ExpressionType.BOOLEAN, OperatorKind.not, expression);
             } else { //'this is '(' boolean_expression ')'

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/TemporalConstraintParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/TemporalConstraintParser.java
@@ -98,7 +98,15 @@ public class TemporalConstraintParser extends BaseTreeWalker {
         //TODO: surround with try catch, do a nice error reporting with line numbers and other nice messages here :)
         CDuration result = new CDuration();
         if(context.DURATION_CONSTRAINT_PATTERN() != null) {
-            result.setPatternedConstraint(context.DURATION_CONSTRAINT_PATTERN().getText());
+
+            String durationPattern = context.DURATION_CONSTRAINT_PATTERN().getText();
+            //This is a bit of a hack - the duration pattern can be followed by a '/'.
+            // To not clash with path, the lexer has to parse this '/' and include it in the pattern
+            //so remove it here.
+            if(durationPattern.endsWith("/")) {
+                durationPattern = durationPattern.substring(0, durationPattern.length()-1);
+            }
+            result.setPatternedConstraint(durationPattern);
         }
         if(context.assumed_duration_value() != null) {
             result.setAssumedValue(parseDurationValue(context.assumed_duration_value().duration_value().getText()));

--- a/src/test/resources/com/nedap/archie/rules/evaluation/boolean_operand_relops.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/boolean_operand_relops.adls
@@ -25,12 +25,12 @@ definition
 	OBSERVATION[id1]
 
 rules
-	$false_is_not_true:Boolean ::= false != true;
-    $false_is_false:Boolean ::= false = false;
-    $false_is_true:Boolean ::= false = true;
-    $true_is_false:Boolean ::= true = false;
-    $arithmetic_boolean_operands_true:Boolean ::= 1 > 3 = 5 > 8;
-    $arithmetic_boolean_operands_false:Boolean ::= 1 < 3 = 5 > 8;
+	$false_is_not_true:Boolean ::= false != true
+    $false_is_false:Boolean ::= false = false
+    $false_is_true:Boolean ::= false = true
+    $true_is_false:Boolean ::= true = false
+    $arithmetic_boolean_operands_true:Boolean ::= 1 > 3 = 5 > 8
+    $arithmetic_boolean_operands_false:Boolean ::= 1 < 3 = 5 > 8
 
 terminology
 	term_definitions = <

--- a/src/test/resources/com/nedap/archie/rules/evaluation/calculated_path_values.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/calculated_path_values.adls
@@ -67,11 +67,11 @@ definition
 	}
 
 rules
-	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude;
+	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
 
-	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude;
+	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
 
-	/data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude = $systolic - $diastolic;
+	/data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude = $systolic - $diastolic
 
 
 

--- a/src/test/resources/com/nedap/archie/rules/evaluation/calculated_path_values_2.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/calculated_path_values_2.adls
@@ -76,13 +76,13 @@ definition
 	}
 
 rules
-	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude;
+	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
 
-	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude;
+	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
 
-	/data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude = $systolic - $diastolic;
+	/data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude = $systolic - $diastolic
 
-	/data[id2]/events[id3]/data[id4]/items[id8]/value/magnitude = /data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude + 3;
+	/data[id2]/events[id3]/data[id4]/items[id8]/value/magnitude = /data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude + 3
 
 
 

--- a/src/test/resources/com/nedap/archie/rules/evaluation/exists.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/exists.adls
@@ -67,13 +67,13 @@ definition
 	}
 
 rules
-	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude;
+	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
 
-	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude;
+	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
 
-    path_systolic: exists /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude;
-    path_diastolic: exists /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude;
-    for_all_systolic: for_all $event in /data[id2]/events[id3] satisfies exists $event/data[id4]/items[id5]/value/magnitude;
+    path_systolic: exists /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
+    path_diastolic: exists /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
+    for_all_systolic: for_all $event in /data[id2]/events[id3] satisfies exists $event/data[id4]/items[id5]/value/magnitude
 
 terminology
 	term_definitions = <

--- a/src/test/resources/com/nedap/archie/rules/evaluation/extended_calculated_path_values.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/extended_calculated_path_values.adls
@@ -78,7 +78,7 @@ definition
 rules
 	/data[id2]/events[id3]/data[id4]/items[id8]/value/magnitude = /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
 	    + /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
-	    + /data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude;
+	    + /data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude
 
 
 

--- a/src/test/resources/com/nedap/archie/rules/evaluation/for_all.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/for_all.adls
@@ -58,8 +58,8 @@ definition
 	}
 
 rules
-	blood_pressure_valid: for_all $event in /data[id2]/events satisfies
-	    $event/data[id4]/items[id5]/value/magnitude > $event/data[id4]/items[id6]/value/magnitude - 5;
+	blood_pressure_valid: for_all $event in /data[id2]/events
+	    $event/data[id4]/items[id5]/value/magnitude > $event/data[id4]/items[id6]/value/magnitude - 5
 
 
 

--- a/src/test/resources/com/nedap/archie/rules/evaluation/for_all_calculated_path_values.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/for_all_calculated_path_values.adls
@@ -67,9 +67,9 @@ definition
 	}
 
 rules
-	for_all $event in /data[id2]/events[id3] satisfies
+	for_all $event in /data[id2]/events[id3]
 		$event/data[id4]/items[id7]/value/magnitude =
-			$event/data[id4]/items[id5]/value/magnitude - $event/data[id4]/items[id6]/value/magnitude;
+			$event/data[id4]/items[id5]/value/magnitude - $event/data[id4]/items[id6]/value/magnitude
 
 
 

--- a/src/test/resources/com/nedap/archie/rules/evaluation/implies.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/implies.adls
@@ -67,9 +67,9 @@ definition
 	}
 
 rules
-    path_systolic: exists /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude implies exists /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude;
-    must_exists: every $event in /data[id2]/events[id3] satisfies (exists $event/data[id4]/items[id5]/value/magnitude implies exists $event/data[id4]/items[id6]/value/magnitude);
-    must_set_value: every $event in /data[id2]/events[id3] satisfies ($event/data[id4]/items[id5]/value/magnitude > 3 implies $event/data[id4]/items[id6]/value/magnitude = 6);
+    path_systolic: exists /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude implies exists /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
+    must_exists: every $event in /data[id2]/events[id3] (exists $event/data[id4]/items[id5]/value/magnitude implies exists $event/data[id4]/items[id6]/value/magnitude)
+    must_set_value: every $event in /data[id2]/events[id3] ($event/data[id4]/items[id5]/value/magnitude > 3 implies $event/data[id4]/items[id6]/value/magnitude = 6)
 terminology
 	term_definitions = <
 		["en"] = <

--- a/src/test/resources/com/nedap/archie/rules/evaluation/matches.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/matches.adls
@@ -51,7 +51,7 @@ definition
 	}
 
 rules
-	$extended_validity:Boolean ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude matches {|0.0..30.0|};
+	$extended_validity:Boolean ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude matches {|0.0..30.0|}
 
 terminology
 	term_definitions = <

--- a/src/test/resources/com/nedap/archie/rules/evaluation/modelreferences.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/modelreferences.adls
@@ -51,9 +51,9 @@ definition
 	}
 
 rules
-	$arithmetic_test:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude;
+	$arithmetic_test:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
 
-	blood_pressure_valid: $arithmetic_test > 50;
+	blood_pressure_valid: $arithmetic_test > 50
 
 
 

--- a/src/test/resources/com/nedap/archie/rules/evaluation/multiplicity.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/multiplicity.adls
@@ -59,11 +59,11 @@ definition
 
 rules
 	--do not actually use this pattern this way unless you know what you are doing - see for_all.adls on what you should do in this case
-	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude;
+	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
 
-	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude;
+	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
 
-	blood_pressure_valid: $systolic > $diastolic - 5;
+	blood_pressure_valid: $systolic > $diastolic - 5
 
 
 

--- a/src/test/resources/com/nedap/archie/rules/evaluation/not_exists.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/not_exists.adls
@@ -67,13 +67,13 @@ definition
 	}
 
 rules
-	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude;
+	$systolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
 
-	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude;
+	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
 
-    path_systolic: not exists /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude;
-    path_diastolic: not exists /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude;
-    for_all_systolic: for_all $event in /data[id2]/events[id3] satisfies not exists $event/data[id4]/items[id5]/value/magnitude;
+    path_systolic: not exists /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
+    path_diastolic: not exists /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
+    for_all_systolic: for_all $event in /data[id2]/events[id3] not exists $event/data[id4]/items[id5]/value/magnitude
 
 terminology
 	term_definitions = <

--- a/src/test/resources/com/nedap/archie/rules/evaluation/simplearithmetic.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/simplearithmetic.adls
@@ -25,14 +25,14 @@ definition
 	OBSERVATION[id1]
 
 rules
-	$arithmetic_test:Integer ::= 3 * 5 + 2 * 2 - 15 + 4;
-    $boolean_false_test:Boolean ::= 3 > 5 + 6 * 7 + 3 * 23 + 8 / (1 + 2);
-    $boolean_true_test:Boolean ::= 3 < 5 + 6 * 7 + 3 * 23 + 8 / (1 + 2);
-    $boolean_extended_test:Boolean ::= (3 < 5 OR 2 > 1) AND 1 = 1;
-    $not_false:Boolean ::= not false;
-    $not_not_not_true:Boolean ::= ¬~! true;
-    $variable_reference:Integer ::= $arithmetic_test % 5;
-    $arithmetic_parentheses:Integer ::= (3+2)*5;
+	$arithmetic_test:Integer ::= 3 * 5 + 2 * 2 - 15 + 4
+    $boolean_false_test:Boolean ::= 3 > 5 + 6 * 7 + 3 * 23 + 8 / (1 + 2)
+    $boolean_true_test:Boolean ::= 3 < 5 + 6 * 7 + 3 * 23 + 8 / (1 + 2)
+    $boolean_extended_test:Boolean ::= (3 < 5 OR 2 > 1) AND 1 = 1
+    $not_false:Boolean ::= not false
+    $not_not_not_true:Boolean ::= ¬~! true
+    $variable_reference:Integer ::= $arithmetic_test % 5
+    $arithmetic_parentheses:Integer ::= (3+2)*5
 
 
 terminology

--- a/src/test/resources/com/nedap/archie/rules/evaluation/string_literals.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/string_literals.adls
@@ -25,9 +25,9 @@ definition
 	OBSERVATION[id1]
 
 rules
-	$test_neq_test:Boolean ::= "test" != "test";
-    $test_eq_test:Boolean ::= "test" = "test";
-    $string_variable:String ::= "string contents";
+	$test_neq_test:Boolean ::= "test" != "test"
+    $test_eq_test:Boolean ::= "test" = "test"
+    $string_variable:String ::= "string contents"
 
 terminology
 	term_definitions = <


### PR DESCRIPTION
- [x] move path parsing to the lexer
- [x] add preliminary syntax for function calls - no implementation of those yet
- [x] get rid of the ';' and 'satisfies' that are now required to parse rules

The path parsing in the lexer means paths can now be parsed whitespace sensitive. Which means we can get rid of the ';' and satisfies that were added to correctly unambiguously parse the rules language.

This means a lot less warnings about ambiguity, although there seem to be some left, for some reason.

Requires a few minor hacks, especially with the duration constraint parsing with '/' symbol and variable references at the beginning of paths. In other parts, parsing becomes a bit easier.
