### PR TITLE
Less parse logging

### DIFF
--- a/src/main/java/com/nedap/archie/adlparser/ADLErrorListener.java
+++ b/src/main/java/com/nedap/archie/adlparser/ADLErrorListener.java
@@ -36,19 +36,19 @@ public class ADLErrorListener implements ANTLRErrorListener {
     public void reportAmbiguity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, boolean exact, BitSet ambigAlts, ATNConfigSet configs) {
         String input = recognizer.getInputStream().getText(new Interval(startIndex, stopIndex));
         String warning = String.format("FULL AMBIGUITY: %d-%d, exact: %b, input: %s", startIndex, stopIndex, exact, input);
-        logger.warn(warning);
+        logger.debug(warning);
         errors.addWarning(warning);
     }
 
     @Override
     public void reportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs) {
         String input = recognizer.getInputStream().getText(new Interval(startIndex, stopIndex));
-        logger.warn("FULL CONTEXT: {}-{}, alts: {}, {}", startIndex, stopIndex, conflictingAlts, input);
+        logger.debug("FULL CONTEXT: {}-{}, alts: {}, {}", startIndex, stopIndex, conflictingAlts, input);
     }
 
     @Override
     public void reportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs) {
-        logger.warn("CONTEXT SENSITIVITY: {}-{}, prediction: {}", startIndex, stopIndex, prediction);
+        logger.debug("CONTEXT SENSITIVITY: {}-{}, prediction: {}", startIndex, stopIndex, prediction);
     }
 
     public ADLParserErrors getErrors() {

--- a/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
@@ -191,7 +191,7 @@ class FixableAssertionsChecker {
     }
 
     private void setPathsToValues(AssertionResult assertionResult, String path, ValueList value) {
-        logger.info("path {} set to value {} ", path, value);
+        logger.debug("path {} set to value {} ", path, value);
         assertionResult.setSetPathValue(path, value);
     }
 }

--- a/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
@@ -94,7 +94,7 @@ public class RuleEvaluation {
         if(evaluator != null) {
             ValueList valueList = evaluator.evaluate(this, rule);
             ruleElementValueSet(rule, valueList);
-            logger.info("evaluated rule: {}", valueList);
+            logger.debug("evaluated rule: {}", valueList);
             return valueList;
         }
         throw new UnsupportedOperationException("no evaluator present for rule type " + rule.getClass().getSimpleName());


### PR DESCRIPTION
The adl parser logs lots of warnings parsing rules sections due to a less than perfect grammar. But those are only useful when debugging, so make them debug messages instead of warnings :)