### PR TITLE
Performance fixes

### DIFF
--- a/src/main/java/com/nedap/archie/paths/PathSegment.java
+++ b/src/main/java/com/nedap/archie/paths/PathSegment.java
@@ -67,7 +67,7 @@ public class PathSegment {
     public boolean hasNumberIndex() { return index != null;}
 
     public boolean hasArchetypeRef() {
-        return nodeId != null && archetypeRefPattern.matcher(nodeId).matches());
+        return nodeId != null && archetypeRefPattern.matcher(nodeId).matches();
     }
 
     @Override

--- a/src/main/java/com/nedap/archie/paths/PathSegment.java
+++ b/src/main/java/com/nedap/archie/paths/PathSegment.java
@@ -2,12 +2,17 @@ package com.nedap.archie.paths;
 
 import com.google.common.base.Joiner;
 
+import java.util.regex.Pattern;
+
 /**
  * Segment of an apath-query
  * Created by pieter.bos on 19/10/15.
  */
 public class PathSegment {
     private final static Joiner expressionJoiner = Joiner.on(", ").skipNulls();
+
+    private static final Pattern archetypeRefPattern = Pattern.compile("(.*::)?.*-.*-.*\\..*\\.v.*");
+    private static final Pattern nodeIdPattern = Pattern.compile("id(\\.?\\d)+");
 
     private String nodeName;
     private String nodeId;
@@ -56,21 +61,21 @@ public class PathSegment {
     }
 
     public boolean hasIdCode() {
-        return nodeId != null && nodeId.matches("id(\\.?\\d)+");
+        return nodeId != null && nodeIdPattern.matcher(nodeId).matches();
     }
 
     public boolean hasNumberIndex() { return index != null;}
 
     public boolean hasArchetypeRef() {
-        return nodeId != null && nodeId.matches("(.*::)?.*-.*-.*\\..*\\.v.*");
+        return nodeId != null && archetypeRefPattern.matcher(nodeId).matches());
     }
 
     @Override
     public String toString() {
         if(hasExpressions()) {
-            return String.format("/%s[%s]", nodeName, expressionJoiner.join(nodeId, index));
+            return "/" + nodeName + "[" +  expressionJoiner.join(nodeId, index) + "]";
         } else {
-            return String.format("/%s", nodeName);
+            return "/" + nodeName;
         }
     }
 

--- a/src/main/java/com/nedap/archie/query/APathToXPathConverter.java
+++ b/src/main/java/com/nedap/archie/query/APathToXPathConverter.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.query;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.nedap.archie.adlparser.antlr.XPathLexer;
 import com.nedap.archie.adlparser.antlr.XPathParser;
@@ -24,6 +25,9 @@ public class APathToXPathConverter {
     //Pattern is thread-safe and immutable, so fine to store here for performance reasons
     private static Pattern idCodePattern = Pattern.compile("id\\d+");
     private static Pattern numberPattern = Pattern.compile("\\d+");
+    //warning: do NOT modify this set, only create it!
+    private static Set<String> literalsThatShouldHaveSpacing = new ImmutableSet.Builder().add("and", "or", ",", "-", "+", "*", "|", "<", ">", "<=", ">=").build();
+
 
     public static String convertQueryToXPath(String query, String firstNodeName) {
         String convertedQuery = convertWithAntlr(query);
@@ -106,8 +110,6 @@ public class APathToXPathConverter {
     private static void writeTree(StringBuilder output, ParseTree tree, boolean inPredicate) {
 
 
-
-        Set<String> literalsThatShouldHaveSpacing = Sets.<String>newHashSet("and", "or", ",", "-", "+", "*", "|", "<", ">", "<=", ">=");
         for(int i = 0; i < tree.getChildCount(); i++) {
             ParseTree child = tree.getChild(i);
             if(child instanceof TerminalNode) {

--- a/src/main/java/com/nedap/archie/query/APathToXPathConverter.java
+++ b/src/main/java/com/nedap/archie/query/APathToXPathConverter.java
@@ -21,6 +21,10 @@ import java.util.regex.Pattern;
  */
 public class APathToXPathConverter {
 
+    //Pattern is thread-safe and immutable, so fine to store here for performance reasons
+    private static Pattern idCodePattern = Pattern.compile("id\\d+");
+    private static Pattern numberPattern = Pattern.compile("\\d+");
+
     public static String convertQueryToXPath(String query, String firstNodeName) {
         String convertedQuery = convertWithAntlr(query);
         if(query.startsWith("//")) {
@@ -101,8 +105,7 @@ public class APathToXPathConverter {
      */
     private static void writeTree(StringBuilder output, ParseTree tree, boolean inPredicate) {
 
-        Pattern idCodePattern = Pattern.compile("id\\d+");
-        Pattern numberPattern = Pattern.compile("\\d+");
+
 
         Set<String> literalsThatShouldHaveSpacing = Sets.<String>newHashSet("and", "or", ",", "-", "+", "*", "|", "<", ">", "<=", ">=");
         for(int i = 0; i < tree.getChildCount(); i++) {

--- a/src/main/java/com/nedap/archie/query/RMQueryContext.java
+++ b/src/main/java/com/nedap/archie/query/RMQueryContext.java
@@ -34,6 +34,7 @@ import java.util.List;
  */
 public class RMQueryContext {
 
+    private final XPathFactory xPathFactory;
     private Binder<Node> binder;
     private Document domForQueries;
 
@@ -78,6 +79,7 @@ public class RMQueryContext {
         } catch (JAXBException e) {
             throw new RuntimeException(e);
         }
+        xPathFactory = XPathFactory.newInstance();
     }
 
     public Document createBlankDOMDocument(boolean namespaceAware) {
@@ -96,7 +98,7 @@ public class RMQueryContext {
 
     public <T> List<T> findList(String query) throws XPathExpressionException {
         String convertedQuery = APathToXPathConverter.convertQueryToXPath(query, firstXPathNode);
-        XPath xpath = XPathFactory.newInstance().newXPath();
+        XPath xpath = xPathFactory.newXPath();
 
 
         xpath.setNamespaceContext( new ArchieNamespaceResolver(domForQueries));
@@ -137,7 +139,7 @@ public class RMQueryContext {
 
     public List<RMObjectWithPath> findListWithPaths(String query) throws XPathExpressionException {
         String convertedQuery = APathToXPathConverter.convertQueryToXPath(query, firstXPathNode);
-        XPath xpath = XPathFactory.newInstance().newXPath();
+        XPath xpath = xPathFactory.newXPath();
         xpath.setNamespaceContext( new ArchieNamespaceResolver(domForQueries));
         NodeList foundNodes = (NodeList)xpath.evaluate(convertedQuery, domForQueries, XPathConstants.NODESET);
         List<RMObjectWithPath> result = new ArrayList<>();


### PR DESCRIPTION
It's hard to write good code if this thing keeps returning the same object and that object is immutable. Just return more objects.

Will make parsing slightly more expensive, but shouldn't be a problem - this was mainly done before the ModelInfoLookup classes were written, which means it's performant as is.

Also other performance fixes.