### PR TITLE
Functionality to get unique paths from several options more easily

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'org.owasp.dependencycheck'
 
 //apply plugin: 'io.codearte.nexus-staging'
 
-version = '0.3.7'
+version = '0.4.0-SNAPSHOT'
 group = 'com.nedap.healthcare'
 archivesBaseName = 'archie'
 

--- a/src/main/java/com/nedap/archie/query/APathQuery.java
+++ b/src/main/java/com/nedap/archie/query/APathQuery.java
@@ -285,10 +285,8 @@ public class APathQuery {
     }
 
     /**
-     * Deprecated for querying RMObjects. Use RMQueryContext instead.
-     * For querying CObjects there is no other solution yet.
+     * You will want to use RMQueryContext in many cases. For perforamnce reasons, this could still be useful
      */
-    @Deprecated
     public <T> List<RMObjectWithPath> findList(ModelInfoLookup lookup, Object root) {
         List<RMObjectWithPath> currentObjects = Lists.newArrayList(new RMObjectWithPath(root, "/"));
         try {
@@ -341,7 +339,7 @@ public class APathQuery {
                                 //operational templates in RM Objects have their archetype node ID set to an archetype ref. That
                                 //we support. Other things not so much
                                 if (!locatable.getArchetypeNodeId().equals(segment.getNodeId())) {
-                                    throw new IllegalArgumentException("cannot handle RM-queries with node names or archetype references yet");
+                                    continue;
                                 }
 
                             }
@@ -455,7 +453,6 @@ public class APathQuery {
                 if (locatable.getArchetypeNodeId().equals(segment.getNodeId())) {
                     result.add(new RMObjectWithPath(object, path + buildPathConstraint(i, locatable.getArchetypeNodeId())));
                 }
-                throw new IllegalArgumentException("cannot handle RM-queries with archetype references yet");
             } else {
                 if(equalsName(locatable.getNameAsString(), segment.getNodeId())) {
                     result.add(new RMObjectWithPath(object, path + buildPathConstraint(i, locatable.getArchetypeNodeId())));

--- a/src/main/java/com/nedap/archie/query/RMQueryContext.java
+++ b/src/main/java/com/nedap/archie/query/RMQueryContext.java
@@ -136,6 +136,23 @@ public class RMQueryContext {
         return null;
     }
 
+    public Node getNode(Object object) {
+        return binder.getXMLNode(object);
+    }
+
+    public String getUniquePath(Object object) {
+        if(object == null) {
+            return null;
+        }
+        Node node = getNode(object);
+        if(node == null) {
+            return null;
+        } else {
+            return UniqueNodePathBuilder.constructPath(node);
+        }
+    }
+
+
     public List<RMObjectWithPath> findListWithPaths(String query) throws XPathExpressionException {
         String convertedQuery = APathToXPathConverter.convertQueryToXPath(query, firstXPathNode);
         XPath xpath = xPathFactory.newXPath();

--- a/src/main/java/com/nedap/archie/rm/datastructures/ItemTree.java
+++ b/src/main/java/com/nedap/archie/rm/datastructures/ItemTree.java
@@ -2,6 +2,7 @@ package com.nedap.archie.rm.datastructures;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 @XmlType(name = "ITEM_TREE", propOrder = {
         "items"
 })
+@XmlRootElement(name="item_tree")
 public class ItemTree extends ItemStructure<Item> {
         private List<Item> items = new ArrayList<>();
 


### PR DESCRIPTION
- Fixes in APathQuery - which still performs better in many cases than RMQueryContext. A rewrite would be better, but not now.
- getUniquePath functionality in RMQueryContext (warning, still untested)