### PR TITLE
Some fixes in jacoco config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,11 +109,24 @@ classes {
 	dependsOn generateGrammarSource
 }
 
+def generatedSources = ["**/com/nedap/archie/adlparser/antlr**"]
+
+test {
+  jacoco {
+    excludes = generatedSources
+  }
+}
+
 jacocoTestReport {
+    doFirst {
+          classDirectories = fileTree(dir: "${buildDir}/classes/main/").exclude(generatedSources)
+    }
     reports {
         xml.enabled = true
         html.enabled = true
     }
+    sourceSets sourceSets.main
+    //do not check the generated source 
 }
 
 check.dependsOn jacocoTestReport


### PR DESCRIPTION
set jacoco to ignore generated antlr-code - quite a lot will never ever be hit and it's not relevant