### PR TITLE
Rule evaluation fixes

### DIFF
--- a/src/main/antlr/adl_rules.g4
+++ b/src/main/antlr/adl_rules.g4
@@ -49,8 +49,13 @@ booleanAndExpression
 	;
 
 booleanXorExpression
-	:	booleanConstraintExpression
-	|	booleanXorExpression SYM_XOR booleanConstraintExpression
+	:	booleanNotExpression
+	|	booleanXorExpression SYM_XOR booleanNotExpression
+	;
+
+booleanNotExpression
+    : SYM_NOT booleanNotExpression
+    | booleanConstraintExpression
 	;
 
 booleanConstraintExpression
@@ -87,7 +92,6 @@ expressionLeaf
     | string_value
     | adlRulesPath
     | SYM_EXISTS adlRulesPath
-    | SYM_NOT expression
     | functionName '(' (argumentList)? ')'
     | variableReference
     | '(' expression ')'

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -1,7 +1,6 @@
 package com.nedap.archie.adlparser.treewalkers;
 
 import com.nedap.archie.adlparser.ADLParserErrors;
-import com.nedap.archie.adlparser.antlr.AdlParser;
 import com.nedap.archie.adlparser.antlr.AdlParser.*;
 import com.nedap.archie.adlparser.odin.OdinValueParser;
 import com.nedap.archie.aom.CPrimitiveObject;

--- a/src/main/java/com/nedap/archie/aom/terminology/ArchetypeTerm.java
+++ b/src/main/java/com/nedap/archie/aom/terminology/ArchetypeTerm.java
@@ -55,6 +55,16 @@ public class ArchetypeTerm extends ArchetypeModelObject implements Map<String, S
         items.put("description", description);
     }
 
+    public ArchetypeTerm() {
+        super();
+    }
+
+    public ArchetypeTerm(String code, String text, String description) {
+        this.code = code;
+        this.setText(text);
+        this.setDescription(description);
+    }
+
     /**
      * For compatibility with the AOM, the other items is explicitly modelled here. You could just use the map interface
      * implemented here - it is faster and easier (and required for odin-parsing with jackson).

--- a/src/main/java/com/nedap/archie/creation/RMObjectCreator.java
+++ b/src/main/java/com/nedap/archie/creation/RMObjectCreator.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.creation;
 
+import com.google.common.collect.Lists;
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.rm.archetyped.Locatable;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
@@ -132,6 +133,27 @@ public class RMObjectCreator {
 
         } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public void addElementToListOrSetSingleValues(Object object, String attribute, Object element) {
+        RMAttributeInfo attributeInfo = this.classLookup.getAttributeInfo(object.getClass(), attribute);
+        if(!attributeInfo.isMultipleValued()) {
+            if(element instanceof Collection) {
+                set(object, attribute, new ArrayList((Collection) element));
+            } else {
+                set(object, attribute, Lists.newArrayList(element));
+            }
+        } else {
+            if(element instanceof Collection) {
+                Collection collection = (Collection) element;
+                for(Object el:collection) {
+                    addElementToList(object, attributeInfo, el);
+                }
+            } else {
+                addElementToList(object, attributeInfo, element);
+            }
+
         }
     }
 }

--- a/src/main/java/com/nedap/archie/rules/PrimitiveType.java
+++ b/src/main/java/com/nedap/archie/rules/PrimitiveType.java
@@ -28,4 +28,18 @@ public enum PrimitiveType {
         return Unknown;//or throw exception?
 
     }
+
+    public static PrimitiveType fromExpressionType(ExpressionType type) {
+        switch(type) {
+            case STRING:
+                return String;
+            case BOOLEAN:
+                return Boolean;
+            case INTEGER:
+                return Integer;
+            case REAL:
+                return Real;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
@@ -12,7 +12,6 @@ import com.nedap.archie.aom.CPrimitiveTuple;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.base.Interval;
 import com.nedap.archie.creation.RMObjectCreator;
-import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;

--- a/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
@@ -145,7 +145,7 @@ public class AssertionsFixer {
             Object newEmptyObject = null;
             newEmptyObject = constructEmptySimpleObject(newLastPathSegment, object, newEmptyObject);
 
-            creator.set(object, newLastPathSegment, Lists.newArrayList(newEmptyObject));
+            creator.addElementToListOrSetSingleValues(object, newLastPathSegment, Lists.newArrayList(newEmptyObject));
             ruleEvaluation.refreshQueryContext();
             parents = ruleEvaluation.getQueryContext().findList(pathOfParent);
         } else {
@@ -159,12 +159,15 @@ public class AssertionsFixer {
                 } else {
                     newEmptyObject = constructEmptySimpleObject(newLastPathSegment, object, newEmptyObject);
                 }
+
                 int bracketIndex = newLastPathSegment.indexOf('[');
                 String attributeName = newLastPathSegment;
                 if(bracketIndex > -1) {
                     attributeName = newLastPathSegment.substring(0, bracketIndex);
                 }
-                creator.set(object, attributeName, Lists.newArrayList(newEmptyObject));
+
+                creator.addElementToListOrSetSingleValues(object, attributeName, Lists.newArrayList(newEmptyObject));
+
                 ruleEvaluation.refreshQueryContext();
                 parents = ruleEvaluation.getQueryContext().findList(pathOfParent);
             }

--- a/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
@@ -12,6 +12,7 @@ import com.nedap.archie.aom.CPrimitiveTuple;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.base.Interval;
 import com.nedap.archie.creation.RMObjectCreator;
+import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;
@@ -158,7 +159,12 @@ public class AssertionsFixer {
                 } else {
                     newEmptyObject = constructEmptySimpleObject(newLastPathSegment, object, newEmptyObject);
                 }
-                creator.set(object, newLastPathSegment, Lists.newArrayList(newEmptyObject));
+                int bracketIndex = newLastPathSegment.indexOf('[');
+                String attributeName = newLastPathSegment;
+                if(bracketIndex > -1) {
+                    attributeName = newLastPathSegment.substring(0, bracketIndex);
+                }
+                creator.set(object, attributeName, Lists.newArrayList(newEmptyObject));
                 ruleEvaluation.refreshQueryContext();
                 parents = ruleEvaluation.getQueryContext().findList(pathOfParent);
             }

--- a/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
@@ -65,6 +65,9 @@ class FixableAssertionsChecker {
                 handleImplies(assertionResult, index, binaryExpression);
             } else if (binaryExpression.getOperator() == OperatorKind.matches) {
                 handleMatches(assertionResult, index, binaryExpression);
+            } else if (binaryExpression.getOperator() == OperatorKind.and) {
+                checkAssertionForFixablePatterns(assertionResult, binaryExpression.getLeftOperand(), index);
+                checkAssertionForFixablePatterns(assertionResult, binaryExpression.getRightOperand(), index);
             }
         } else if (expression instanceof UnaryOperator) {
             UnaryOperator unaryOperator = (UnaryOperator) expression;

--- a/src/main/java/com/nedap/archie/rules/evaluation/ValueList.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/ValueList.java
@@ -44,6 +44,14 @@ public class ValueList {
         this(value, Collections.EMPTY_LIST);
     }
 
+    /*
+     * Construct a value list of a single value, that does not have a path.
+     */
+    public ValueList(Object value, PrimitiveType type) {
+        this(value, Collections.EMPTY_LIST);
+        setType(type);
+    }
+
     /**
      * Construct a value list of a single object, with its paths
      * @param value
@@ -52,6 +60,7 @@ public class ValueList {
     public ValueList(Object value, List<String> paths){
         if(value == null) {
             this.type = null;
+            addValue(value, paths);
         } else {
             addValue(value, paths);
 

--- a/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -147,9 +147,15 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
                 if(leftBoolean == null && rightBoolean == null) {
                     return null;
                 } else if (leftBoolean == null) {
-                    return rightBoolean;
+                    if(rightBoolean) {
+                        return rightBoolean;
+                    }
+                    return null;
                 } else if (rightBoolean == null) {
-                    return leftBoolean;
+                    if(leftBoolean) {
+                        return leftBoolean;
+                    }
+                    return null;
                 }
                 return leftBoolean | rightBoolean;
             case xor:

--- a/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -93,10 +93,12 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
         ValueList leftValues = evaluation.evaluate(statement.getLeftOperand());
         ValueList rightValues = evaluation.evaluate(statement.getRightOperand());
 
-        ValueList possibleNullResult = checkAndHandleNull(leftValues, rightValues);
-        if(possibleNullResult != null) {
-            possibleNullResult.setType(PrimitiveType.Boolean);
-            return possibleNullResult;
+        if(statement.getOperator() != OperatorKind.or) {
+            ValueList possibleNullResult = checkAndHandleNull(leftValues, rightValues);
+            if (possibleNullResult != null) {
+                possibleNullResult.setType(PrimitiveType.Boolean);
+                return possibleNullResult;
+            }
         }
 
 
@@ -142,6 +144,13 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
             case and:
                 return leftBoolean & rightBoolean;
             case or:
+                if(leftBoolean == null && rightBoolean == null) {
+                    return null;
+                } else if (leftBoolean == null) {
+                    return rightBoolean;
+                } else if (rightBoolean == null) {
+                    return leftBoolean;
+                }
                 return leftBoolean | rightBoolean;
             case xor:
                 return leftBoolean ^ rightBoolean;

--- a/src/main/java/com/nedap/archie/rules/evaluation/evaluators/ConstantEvaluator.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/evaluators/ConstantEvaluator.java
@@ -2,6 +2,7 @@ package com.nedap.archie.rules.evaluation.evaluators;
 
 import com.google.common.collect.Lists;
 import com.nedap.archie.rules.Constant;
+import com.nedap.archie.rules.PrimitiveType;
 import com.nedap.archie.rules.evaluation.Evaluator;
 import com.nedap.archie.rules.evaluation.RuleEvaluation;
 import com.nedap.archie.rules.evaluation.ValueList;
@@ -14,7 +15,7 @@ import java.util.List;
 public class ConstantEvaluator implements Evaluator<Constant> {
     @Override
     public ValueList evaluate(RuleEvaluation evaluation, Constant statement) {
-        return new ValueList(statement.getValue());
+        return new ValueList(statement.getValue(), PrimitiveType.fromExpressionType(statement.getType()));
     }
 
     @Override

--- a/src/test/java/com/nedap/archie/creation/RMObjectCreatorTest.java
+++ b/src/test/java/com/nedap/archie/creation/RMObjectCreatorTest.java
@@ -42,6 +42,22 @@ public class RMObjectCreatorTest {
         assertEquals("id6", e.getArchetypeNodeId());
     }
 
+    @Test(expected=IllegalArgumentException.class)
+    public void createUnknownType() {
+        Archetype archetype = new AuthoredArchetype();
+        archetype.setTerminology(new ArchetypeTerminology());
+        LinkedHashMap<String, ArchetypeTerm> termDefinitions = new LinkedHashMap<>();
+        termDefinitions.put("id6", new ArchetypeTerm("id6", "text", "description"));
+        archetype.getTerminology().getTermDefinitions().put("en", termDefinitions);
+
+        CComplexObject elementConstraint = new CComplexObject();
+        elementConstraint.setRmTypeName("DOUBLE");
+        elementConstraint.setNodeId("id6");
+        archetype.setDefinition(elementConstraint);
+
+        Object o = creator.create(elementConstraint);
+    }
+
     @Test
     public void setSingleValuedValue() {
         Element element = new Element();
@@ -50,12 +66,26 @@ public class RMObjectCreatorTest {
         assertEquals(booleanValue, element.getValue());
     }
 
+    @Test
+    public void setSingleValuedValuePrimitive() {
+        DvBoolean booleanValue = new DvBoolean();
+        creator.set(booleanValue, "value", Lists.newArrayList(true));
+        assertEquals(true, booleanValue.getValue());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void setSingleValuedValueIncorrectly() {
         Element element = new Element();
         DvBoolean booleanValue = new DvBoolean();
         DvBoolean booleanValue2 = new DvBoolean();
         creator.set(element, "value", Lists.newArrayList(booleanValue, booleanValue2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setSingleValuedValueUnknownArgument() {
+        Element element = new Element();
+        DvBoolean booleanValue = new DvBoolean();
+        creator.set(element, "values", Lists.newArrayList(booleanValue));
     }
 
     @Test

--- a/src/test/java/com/nedap/archie/creation/RMObjectCreatorTest.java
+++ b/src/test/java/com/nedap/archie/creation/RMObjectCreatorTest.java
@@ -1,0 +1,125 @@
+package com.nedap.archie.creation;
+
+import com.google.common.collect.Lists;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.AuthoredArchetype;
+import com.nedap.archie.aom.CComplexObject;
+import com.nedap.archie.aom.terminology.ArchetypeTerm;
+import com.nedap.archie.aom.terminology.ArchetypeTerminology;
+import com.nedap.archie.rm.datastructures.Cluster;
+import com.nedap.archie.rm.datastructures.Element;
+import com.nedap.archie.rm.datavalues.DvBoolean;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by pieter.bos on 10/05/2017.
+ */
+public class RMObjectCreatorTest {
+
+    RMObjectCreator creator = new RMObjectCreator();
+
+    @Test
+    public void createElement() {
+        Archetype archetype = new AuthoredArchetype();
+        archetype.setTerminology(new ArchetypeTerminology());
+        LinkedHashMap<String, ArchetypeTerm> termDefinitions = new LinkedHashMap<>();
+        termDefinitions.put("id6", new ArchetypeTerm("id6", "text", "description"));
+        archetype.getTerminology().getTermDefinitions().put("en", termDefinitions);
+
+        CComplexObject elementConstraint = new CComplexObject();
+        elementConstraint.setRmTypeName("ELEMENT");
+        elementConstraint.setNodeId("id6");
+        archetype.setDefinition(elementConstraint);
+
+        Object o = creator.create(elementConstraint);
+        assertEquals(Element.class, o.getClass());
+        Element e = (Element) o;
+        assertEquals("text", e.getName().getValue());
+        assertEquals("id6", e.getArchetypeNodeId());
+    }
+
+    @Test
+    public void setSingleValuedValue() {
+        Element element = new Element();
+        DvBoolean booleanValue = new DvBoolean();
+        creator.set(element, "value", Lists.newArrayList(booleanValue));
+        assertEquals(booleanValue, element.getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setSingleValuedValueIncorrectly() {
+        Element element = new Element();
+        DvBoolean booleanValue = new DvBoolean();
+        DvBoolean booleanValue2 = new DvBoolean();
+        creator.set(element, "value", Lists.newArrayList(booleanValue, booleanValue2));
+    }
+
+    @Test
+    public void setMultiValuedValue() {
+        Cluster cluster = new Cluster();
+        Element element = new Element();
+        creator.set(cluster, "items", Lists.newArrayList(element));
+        assertEquals(Lists.newArrayList(element), cluster.getItems());
+    }
+
+    @Test
+    public void setMultiValuedValue2() {
+        Cluster cluster = new Cluster();
+        Element element = new Element();
+        Element element2 = new Element();
+        creator.set(cluster, "items", Lists.newArrayList(element, element2));
+        assertEquals(Lists.newArrayList(element, element2), cluster.getItems());
+    }
+
+    @Test
+    public void addToListOrSetSingleValue() {
+        Cluster cluster = new Cluster();
+        Element element = new Element();
+        Element element2 = new Element();
+        creator.set(cluster, "items", Lists.newArrayList(element));
+        creator.addElementToListOrSetSingleValues(cluster, "items", element2);
+        assertEquals(Lists.newArrayList(element, element2), cluster.getItems());
+    }
+
+    @Test
+    public void addToListOrSetSingleValue2() {
+        Cluster cluster = new Cluster();
+        Element element = new Element();
+        Element element2 = new Element();
+        Element element3 = new Element();
+        creator.set(cluster, "items", Lists.newArrayList(element));
+        creator.addElementToListOrSetSingleValues(cluster, "items", Lists.newArrayList(element2, element3));
+        assertEquals(Lists.newArrayList(element, element2, element3), cluster.getItems());
+    }
+
+    @Test
+    public void addToListOrSetSingleValueWithSingleValue() {
+        Element element = new Element();
+        DvBoolean booleanValue = new DvBoolean();
+        creator.addElementToListOrSetSingleValues(element, "value", booleanValue);
+        assertEquals(booleanValue, element.getValue());
+    }
+
+    @Test
+    public void addToListOrSetSingleValueWithSingleValue2() {
+        Element element = new Element();
+        DvBoolean booleanValue = new DvBoolean();
+        creator.addElementToListOrSetSingleValues(element, "value", Lists.newArrayList(booleanValue));
+        assertEquals(booleanValue, element.getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addToListOrSetSingleValueWithSingleValueIncorrect() {
+        Element element = new Element();
+        DvBoolean booleanValue = new DvBoolean();
+        DvBoolean booleanValue2 = new DvBoolean();
+        creator.addElementToListOrSetSingleValues(element, "value", Lists.newArrayList(booleanValue, booleanValue2));
+        assertEquals(booleanValue, element.getValue());
+    }
+
+
+}

--- a/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
+++ b/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
@@ -76,6 +76,20 @@ public class BinaryOperatorTest {
         testBinaryOperator(8d, ExpressionType.REAL, 2d, 3d, OperatorKind.exponent);
     }
 
+    @Test
+    public void or() {
+        testBinaryOperator(true, ExpressionType.BOOLEAN, null, true, OperatorKind.or);
+        testBinaryOperator(true, ExpressionType.BOOLEAN, true, null, OperatorKind.or);
+        testBinaryOperator(null, ExpressionType.BOOLEAN, false, null, OperatorKind.or);
+        testBinaryOperator(null, ExpressionType.BOOLEAN, null, false, OperatorKind.or);
+        testBinaryOperator(null, ExpressionType.BOOLEAN, null, null, OperatorKind.or);
+        testBinaryOperator(false, ExpressionType.BOOLEAN, false, false, OperatorKind.or);
+        testBinaryOperator(true, ExpressionType.BOOLEAN, true, false, OperatorKind.or);
+        testBinaryOperator(true, ExpressionType.BOOLEAN, false, true, OperatorKind.or);
+        testBinaryOperator(true, ExpressionType.BOOLEAN, true, true, OperatorKind.or);
+    }
+
+
     private void testBinaryOperator(Object expected, ExpressionType type, Object left, Object right, OperatorKind operatorKind) {
         BinaryOperator operator = new BinaryOperator();
         operator.setOperator(operatorKind);

--- a/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -57,4 +57,35 @@ public class FixableAssertionsCheckerTest {
 
     }
 
+    @Test
+    public void andExpression() throws Exception {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("and.adls"));
+        RuleEvaluation ruleEvaluation = new RuleEvaluation(archetype);
+
+        Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+        assertEquals("there must be three values that must be set", 3, evaluate.getSetPathValues().size());
+
+        //assert that paths must be set to specific values
+        assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());
+        assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string").getValue());
+        assertEquals("at6", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string").getValue());
+
+        //now assert that the RM Object cloned by rule evaluation has been modified with the new values for further evaluation
+        assertEquals("test string", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
+        assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string"));
+        assertEquals("at6", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string"));
+
+        //and of course the DV_ORDINAL and DV_CODED_TEXT should be constructed correctly, with the correct numeric respectively a textual value
+        assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
+        assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/value"));
+
+
+        evaluate = ruleEvaluation.evaluate(ruleEvaluation.getRMRoot(), archetype.getRules().getRules());
+        for(AssertionResult result:evaluate.getAssertionResults()) {
+            assertTrue(result.getResult());
+        }
+
+    }
+
 }

--- a/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -244,7 +244,7 @@ public class ParsedRulesEvaluationTest {
         }
         return root;
     }
-    
+
     public Pathable constructTwoBloodPressureObservationsOneEmptySystolicNoDiastolic() {
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
 
@@ -269,6 +269,26 @@ public class ParsedRulesEvaluationTest {
         return root;
     }
 
+    @Test
+    public void alreadyCorrectCalculatedPathValues() throws Exception {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("calculated_path_values.adls"));
+        RuleEvaluation ruleEvaluation = new RuleEvaluation(archetype);
+
+        Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        DvQuantity systolic = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value[id13]");
+        systolic.setMagnitude(100d);
+        DvQuantity diastolic = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value[id14]");
+        diastolic.setMagnitude(80d);
+
+        DvQuantity something = (DvQuantity) root.itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value");
+        something.setMagnitude(20.0d);
+
+        EvaluationResult evaluationResult = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+        assertEquals(1, evaluationResult.getAssertionResults().size());
+        assertTrue(evaluationResult.getAssertionResults().get(0).getResult());
+        assertEquals(1, evaluationResult.getSetPathValues().size());
+        assertEquals(20.0d, (Double) evaluationResult.getSetPathValues().values().iterator().next().getValue(), 0.0001d);
+    }
 
 
     @Test

--- a/src/test/resources/com/nedap/archie/rules/evaluation/and.adls
+++ b/src/test/resources/com/nedap/archie/rules/evaluation/and.adls
@@ -1,0 +1,89 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+	openEHR-EHR-OBSERVATION.matches.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Test for rules, simple constant arithmetics">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+	OBSERVATION[id1] matches {	-- Body mass index
+		data matches {
+			HISTORY[id2] matches {
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[id3] occurrences matches {1..*} matches {	-- Any event
+						data matches {
+							ITEM_TREE[id4] matches {
+								items cardinality matches {1..*; unordered} matches {
+									ELEMENT[id5] matches {
+									    value matches {
+                                            DV_TEXT[id64]
+                                        }
+									}
+									ELEMENT[id6] matches {
+                                        value matches {
+                                            DV_CODED_TEXT[id54] matches {
+                                                defining_code matches {[ac1]}
+                                            }
+										}
+									}
+									ELEMENT[id7] matches {
+                                        value matches {
+                                            DV_ORDINAL[id75] matches {
+                                                [value, symbol] matches {
+                                                    [{0}, {[at6]}],
+                                                    [{1}, {[at7]}],
+                                                    [{2}, {[at8]}]
+                                                }
+                                            }
+                                        }
+                                    }
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+rules
+	/data[id2]/events[id3]/data[id4]/items[id5]/value/value matches {"test string"} and
+	/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code matches {[at1]} and
+	/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol matches {[at6]}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Blood Pressure">
+				description = <"The local measurement of arterial blood pressure which is a surrogate for arterial. pressure in the systemic circulation.  Most commonly, use of the term 'blood pressure' refers to measurement of brachial artery pressure in the upper arm.">
+			>
+			["at1"] = <
+                text = <"Option 1">
+                description = <"Option 1">
+            >
+		>
+    >
+    value_sets = <
+        ["ac1"] = <
+            id = <"ac1">
+            members = <"at1", "at2", "at3">
+        >
+    >
+


### PR DESCRIPTION
Two expressions in the form:
```
rules
   /data[id3]/value = 3 and /data[id4]/value = 4
```

Should result in two paths that must be set to a value - this was not implemented yet

- [x] implementation
- [x] test

Also:

- fix NOT operator precedence
- fix an error in the missing structure creation in the assertionsfixer
- if one of the two operands in an OR expression evaluates to true, return true even if the other is null