### PR TITLE
Flattening fixes and improvements

### DIFF
--- a/src/main/antlr/cadl.g4
+++ b/src/main/antlr/cadl.g4
@@ -30,7 +30,7 @@ c_non_primitive_object:
     | archetype_slot
     ;
 
-c_archetype_root: SYM_USE_ARCHETYPE type_id '[' ID_CODE SYM_COMMA archetype_ref ']' c_occurrences? ;
+c_archetype_root: SYM_USE_ARCHETYPE type_id '[' ID_CODE SYM_COMMA archetype_ref ']' c_occurrences? ( SYM_MATCHES '{' c_attribute_def+ '}' )? ;
 
 c_complex_object_proxy: SYM_USE_NODE type_id '[' ID_CODE ']' c_occurrences? adl_path ;
 

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
@@ -203,6 +203,9 @@ public class CComplexObjectParser extends BaseTreeWalker {
         root.setArchetypeRef(archetypeRootContext.archetype_ref().getText());
 
         root.setOccurrences(this.parseMultiplicityInterval(archetypeRootContext.c_occurrences()));
+        for (C_attribute_defContext attributeContext : archetypeRootContext.c_attribute_def()) {
+            parseCAttribute(root, attributeContext);
+        }
 //((Archetype_slotContext) slotContext).start.getInputStream().getText(slotContext.getSourceInterval())
         return root;
     }

--- a/src/main/java/com/nedap/archie/aom/CAttribute.java
+++ b/src/main/java/com/nedap/archie/aom/CAttribute.java
@@ -12,7 +12,6 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -124,20 +123,39 @@ public class CAttribute extends ArchetypeConstraint {
     }
 
 
-    public void replaceChild(String nodeId, CObject definition) {
+    public void replaceChild(String nodeId, CObject constraint) {
 
-        int index = getIndexOfChildWithnodeId(nodeId);
+        int index = getIndexOfChildWithNodeId(nodeId);
         if(index > -1) {
-            children.set(index, definition);
-            definition.setParent(this);
+            children.set(index, constraint);
+            constraint.setParent(this);
         } else {
-            addChild(definition);
+            addChild(constraint);
         }
-
 
     }
 
-    private int getIndexOfChildWithnodeId(String nodeId) {
+    public void replaceChildren(String nodeId, List<CObject> toReplaceParentWith, boolean keepOriginal) {
+        int index = getIndexOfChildWithNodeId(nodeId);
+        if(index > -1) {
+            List<CObject> childrenBefore = children.subList(0, index+1);
+            if(!keepOriginal) {
+                childrenBefore.remove(index);
+            }
+            childrenBefore.addAll(toReplaceParentWith);
+            //List<CObject> childrenAfter = children.subList(index, children.size());
+            for(CObject constraint:toReplaceParentWith) {
+                constraint.setParent(this);
+            }
+        } else {
+            for(CObject constraint:toReplaceParentWith) {
+                addChild(constraint);
+            }
+        }
+
+    }
+
+    private int getIndexOfChildWithNodeId(String nodeId) {
         for(int i = 0; i < children.size(); i++) {
             CObject child = children.get(i);
             if(nodeId.equals(child.getNodeId())) {
@@ -217,6 +235,7 @@ public class CAttribute extends ArchetypeConstraint {
         }
         return false;
     }
+
     //TODO: congruent and conforms to?
 
 }

--- a/src/main/java/com/nedap/archie/aom/ResourceDescription.java
+++ b/src/main/java/com/nedap/archie/aom/ResourceDescription.java
@@ -98,8 +98,8 @@ public class ResourceDescription extends ArchetypeModelObject {
         return licence;
     }
 
-    public void setLicence(String license) {
-        this.licence = license;
+    public void setLicence(String licence) {
+        this.licence = licence;
     }
 
     public Map<String, String> getIpAcknowledgements() {

--- a/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -102,9 +102,9 @@ public class Flattener {
             }
         }
 
-        while(parent.getParentArchetypeId() != null && parent.isDifferential()) {
+        if(parent.getParentArchetypeId() != null) {
             //parent needs flattening first
-            parent = getNewFlattener().flatten(parent);//TODO: this might end up in an infinite loop. Detect depth?
+            parent = getNewFlattener().flatten(parent);
         }
 
 

--- a/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -325,11 +325,11 @@ public class Flattener {
             if (archetype == null) {
                 throw new IllegalArgumentException("Archetype with reference :" + archetypeRef + " not found.");
             }
-            if (archetype.getParentArchetypeId() != null) {
+            //if (archetype.getParentArchetypeId() != null) {
                 archetype = getNewFlattener().flatten(archetype);
-            } else {
-                archetype = archetype.clone();//make sure we don't change this archetype :)
-            }
+           // } else {
+           //     archetype = archetype.clone();//make sure we don't change this archetype :)
+           // }
 
             //
             CComplexObject rootToFill = root;

--- a/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -327,11 +327,8 @@ public class Flattener {
             if (archetype == null) {
                 throw new IllegalArgumentException("Archetype with reference :" + archetypeRef + " not found.");
             }
-            //if (archetype.getParentArchetypeId() != null) {
-                archetype = getNewFlattener().flatten(archetype);
-           // } else {
-           //     archetype = archetype.clone();//make sure we don't change this archetype :)
-           // }
+
+            archetype = getNewFlattener().flatten(archetype);
 
             //
             CComplexObject rootToFill = root;
@@ -562,7 +559,6 @@ public class Flattener {
         if(parent == null) {
             CAttribute childCloned = specialized.clone();
             root.addAttribute(childCloned);
-            parent = childCloned;
         } else {
             parent.setMultiple(getPossiblyOverridenValue(parent.isMultiple(), specialized.isMultiple()));
             parent.setExistence(getPossiblyOverridenValue(parent.getExistence(), specialized.getExistence()));

--- a/src/main/java/com/nedap/archie/query/APathQuery.java
+++ b/src/main/java/com/nedap/archie/query/APathQuery.java
@@ -510,4 +510,8 @@ public class APathQuery {
         return name.equalsIgnoreCase(nameFromQuery);
 
     }
+
+    public List<PathSegment> getPathSegments() {
+        return pathSegments;
+    }
 }

--- a/src/main/java/com/nedap/archie/query/APathToXPathConverter.java
+++ b/src/main/java/com/nedap/archie/query/APathToXPathConverter.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 public class APathToXPathConverter {
 
     //Pattern is thread-safe and immutable, so fine to store here for performance reasons
-    private static Pattern idCodePattern = Pattern.compile("id\\d+");
+    private static Pattern idCodePattern = Pattern.compile("id(\\d|\\.)+");
     private static Pattern numberPattern = Pattern.compile("\\d+");
     //warning: do NOT modify this set, only create it!
     private static Set<String> literalsThatShouldHaveSpacing = new ImmutableSet.Builder().add("and", "or", ",", "-", "+", "*", "|", "<", ">", "<=", ">=").build();

--- a/src/main/java/com/nedap/archie/serializer/adl/ADLOdinObjectMapper.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/ADLOdinObjectMapper.java
@@ -86,7 +86,7 @@ public class ADLOdinObjectMapper implements Function<Object, Object> {
                 .put("original_author", desc.getOriginalAuthor())
                 .put("original_publisher", desc.getOriginalPublisher())
                 .put("original_namespace", desc.getOriginalNamespace())
-                .put("license", desc.getLicence())
+                .put("licence", desc.getLicence())
                 .put("copyright", desc.getCopyright())
                 .put("other_contributors", desc.getOtherContributors())
                 .put("custodian_organization", desc.getCustodianOrganisation())

--- a/src/main/java/com/nedap/archie/serializer/adl/ADLOdinObjectMapper.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/ADLOdinObjectMapper.java
@@ -89,7 +89,7 @@ public class ADLOdinObjectMapper implements Function<Object, Object> {
                 .put("licence", desc.getLicence())
                 .put("copyright", desc.getCopyright())
                 .put("other_contributors", desc.getOtherContributors())
-                .put("custodian_organization", desc.getCustodianOrganisation())
+                .put("custodian_organisation", desc.getCustodianOrganisation())
                 .put("custodian_namespace", desc.getCustodianNamespace())
                 .put("resource_package_uri", desc.getResourcePackageUri())
                 .put("ip_acknowledgements", desc.getIpAcknowledgements())

--- a/src/main/java/com/nedap/archie/serializer/adl/ADLOperationalTemplateSerializer.java
+++ b/src/main/java/com/nedap/archie/serializer/adl/ADLOperationalTemplateSerializer.java
@@ -18,13 +18,17 @@ class ADLOperationalTemplateSerializer extends ADLAuthoredArchetypeSerializer<Op
     protected String serialize() {
         super.serialize();
         builder.newline().append("component_terminologies").newIndentedLine()
+                .append("< ") //todo: this should perhaps be in the ODIN serializer?
+                .indent()
                 .odin(archetype.getComponentTerminologies())
+                .unindent()
+                .append("> ")
                 .unindent();
         return builder.toString();
     }
 
     @Override
     protected String headTag() {
-        return "opertional_template";
+        return "operational_template";
     }
 }

--- a/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
+++ b/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
@@ -82,7 +82,7 @@ public class RulesFlattenerTest {
 
         //test that we can actually parse the output
         ADLParser parser = new ADLParser();
-        Archetype parsed = parser.parse(ADLArchetypeSerializer.serialize(flattened));
+        parser.parse(ADLArchetypeSerializer.serialize(flattened));
         assertTrue(parser.getErrors().hasNoErrors());
     }
 

--- a/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
+++ b/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by pieter.bos on 15/05/2017.
@@ -61,7 +62,7 @@ public class RulesFlattenerTest {
     }
 
     @Test
-    public void flattenedRules() {
+    public void flattenedRules() throws Exception {
         Archetype flattened = flattener.flatten(containingRules);
         CObject systolicCObject = new APathQuery("/content[id5]/data/events/data/items[id5]").find(flattened.getDefinition());
         assertEquals("systolic", systolicCObject.getTerm().getText());
@@ -78,6 +79,11 @@ public class RulesFlattenerTest {
         assertEquals("specialized_rules_blood_pressure", bloodPressure.getTag());
         assertEquals(BinaryOperator.class, biggerThan90.getExpression().getClass());
         assertEquals("/content[id5]/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", ((ModelReference)((BinaryOperator)biggerThan90.getExpression()).getLeftOperand()).getPath());
+
+        //test that we can actually parse the output
+        ADLParser parser = new ADLParser();
+        Archetype parsed = parser.parse(ADLArchetypeSerializer.serialize(flattened));
+        assertTrue(parser.getErrors().hasNoErrors());
     }
 
 }

--- a/src/test/java/com/nedap/archie/query/RMQueryContextTest.java
+++ b/src/test/java/com/nedap/archie/query/RMQueryContextTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Lists;
 import com.nedap.archie.ArchieLanguageConfiguration;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.rm.RMObject;
 import com.nedap.archie.rm.archetyped.Locatable;
 import com.nedap.archie.rm.archetyped.Pathable;
 import com.nedap.archie.rm.composition.Composition;

--- a/src/test/java/com/nedap/archie/query/RMQueryContextTest.java
+++ b/src/test/java/com/nedap/archie/query/RMQueryContextTest.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Lists;
 import com.nedap.archie.ArchieLanguageConfiguration;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.rm.RMObject;
+import com.nedap.archie.rm.archetyped.Locatable;
 import com.nedap.archie.rm.archetyped.Pathable;
 import com.nedap.archie.rm.composition.Composition;
 import com.nedap.archie.rm.datavalues.DvText;
@@ -42,6 +44,18 @@ public class RMQueryContextTest {
         RMQueryContext queryContext = new RMQueryContext(root);
         assertEquals(Lists.newArrayList(composition.getContext()), queryContext.findList("/context"));
         DvText text = (DvText) queryContext.findList("/context/other_context/items[name/value = 'Qualification']/items[id5]/value").get(0);
+        assertNotNull(text);
+    }
+
+    @Test
+    public void withDotInNodeId() throws Exception {
+        root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        Composition composition = (Composition) root;
+
+        ((Locatable) ((Composition) root).getContext().getOtherContext().getItems().get(0)).setArchetypeNodeId("id3.1");
+        RMQueryContext queryContext = new RMQueryContext(root);
+        assertEquals(Lists.newArrayList(composition.getContext()), queryContext.findList("/context"));
+        DvText text = (DvText) queryContext.findList("/context/other_context/items[id3.1]/items[id5]/value").get(0);
         assertNotNull(text);
     }
 

--- a/src/test/resources/com/nedap/archie/flattener/openEHR-EHR-COMPOSITION.blood_pressure_with_synopsis.v1.0.0.adlt
+++ b/src/test/resources/com/nedap/archie/flattener/openEHR-EHR-COMPOSITION.blood_pressure_with_synopsis.v1.0.0.adlt
@@ -1,0 +1,49 @@
+template (adl_version=2.0.5; rm_release=1.0.2; generated)
+	openEHR-EHR-OBSERVATION.blood_pressure_with_synopsis.v1.0.0
+
+specialize
+	openEHR-EHR-COMPOSITION.report-result-with-synopsis.v1
+
+language
+	original_language = <[ISO_639-1::nl]>
+
+description
+	lifecycle_state = <"unmanaged">
+	original_author = <
+		["name"] = <"Pieter Bos">
+		["organisation"] = <"Nedap">
+		["email"] = <"pieter.bos@nedap.com">
+	>
+	copyright = <"none">
+	details = <
+		["nl"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"specialized archetypes test">
+			use = <"testing specialized archetypes">
+			keywords = <"test">
+			misuse = <"">
+		>
+	>
+
+definition
+	 COMPOSITION[id1.1.1.1] matches {
+        content matches {
+            use_archetype OBSERVATION[id2.1, openEHR-EHR-OBSERVATION.blood_pressure.v1]
+            allow_archetype OBSERVATION[id2.1] closed
+        }
+    }
+
+
+terminology
+	term_definitions = <
+		["nl"] = <
+			["id1.1.1.1"] = <
+				text = <"Blood pressure with optionally a synopsis">
+				description = <"Blood pressure with optionally a synopsis">
+			>
+			["id2.1"] = <
+                text = <"Blood pressure">
+                description = <"Blood pressure">
+            >
+		>
+	>

--- a/src/test/resources/com/nedap/archie/flattener/openEHR-EHR-COMPOSITION.report-result-with-synopsis.v1.0.0.adls
+++ b/src/test/resources/com/nedap/archie/flattener/openEHR-EHR-COMPOSITION.report-result-with-synopsis.v1.0.0.adls
@@ -1,0 +1,53 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+	openEHR-EHR-COMPOSITION.report-result-with-synopsis.v1.0.0
+
+specialize
+	openEHR-EHR-COMPOSITION.report-result.v1
+
+language
+	original_language = <[ISO_639-1::nl]>
+
+description
+	lifecycle_state = <"unmanaged">
+	original_author = <
+		["name"] = <"Pieter Bos">
+		["organisation"] = <"Nedap">
+		["email"] = <"pieter.bos@nedap.com">
+	>
+	copyright = <"none">
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To report results together with a clinical synopsis">
+			use = <"To report results together with a clinical synopsis">
+			keywords = <"report", "result report", "synopsis">
+			misuse = <"">
+		>
+	>
+
+definition
+	 COMPOSITION[id1.1.1] matches {
+        content matches {
+            allow_archetype OBSERVATION[id2]
+            use_archetype EVALUATION[id3, openEHR-EHR-EVALUATION.clinical_synopsis.v1] occurrences matches {0..*}
+        }
+    }
+
+
+terminology
+	term_definitions = <
+		["nl"] = <
+			["id1.1.1"] = <
+				text = <"Rapportage met resultaat van een meting en samenvatting">
+				description = <"Rapportage met resultaat van een meting en samenvatting">
+			>
+			["id2"] = <
+                text = <"Een observatie">
+                description = <"Een observatie">
+            >
+            ["id3"] = <
+                text = <"Opmerkingen">
+                description = <"Opmerkingen bij de metingen">
+            >
+		>
+	>

--- a/src/test/resources/com/nedap/archie/flattener/openEHR-EHR-EVALUATION.clinical_synopsis.v1.0.0.adls
+++ b/src/test/resources/com/nedap/archie/flattener/openEHR-EHR-EVALUATION.clinical_synopsis.v1.0.0.adls
@@ -1,0 +1,231 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+	openEHR-EHR-EVALUATION.clinical_synopsis.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			author = <
+				["name"] = <"Nadim Anani">
+				["organisation"] = <"Health Informatics Centre, Karolinska Institutet, Sweden">
+			>
+			accreditation = <"fluent in both English and German, Medical Informatics 'MSc' degree from Heidelberg, 2 years professional experience in health informatics, some translation experience, openEHR knowledge.">
+		>
+		["zh-cn"] = <
+			language = <[ISO_639-1::zh-cn]>
+			author = <
+				["name"] = <"Lin Zhang">
+				["organisation"] = <"BIPH">
+			>
+			accreditation = <"What goes here?">
+		>
+		["ar-sy"] = <
+			language = <[ISO_639-1::ar-sy]>
+			author = <
+				["name"] = <"Mona Saleh">
+			>
+		>
+		["es-ar"] = <
+			language = <[ISO_639-1::es-ar]>
+			author = <
+				["name"] = <"Dr. Leonardo Der Jachadurian">
+				["organisation"] = <"Bitios.com">
+			>
+			accreditation = <"Medical Doctor (Internal Medicine Specialist)">
+		>
+		["fa"] = <
+			language = <[ISO_639-1::fa]>
+			author = <
+				["name"] = <"Shahla Foozonkhah">
+				["organisation"] = <"Ocean Informatics">
+				["email"] = <"shahla.foozonkhah@oceaninformatics.com">
+			>
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			author = <
+				["name"] = <"Emerson Urushibata">
+				["organisation"] = <"Universidade de São Paulo">
+			>
+		>
+	>
+
+description
+	lifecycle_state = <"unmanaged">
+	original_author = <
+		["name"] = <"Sam Heard">
+		["organisation"] = <"Ocean Informatics, Australia">
+		["email"] = <"sam.heard@oceaninformatics.com">
+		["date"] = <"2007-01-09">
+	>
+	copyright = <"© openEHR Foundation">
+	details = <
+		["fa"] = <
+			language = <[ISO_639-1::fa]>
+			purpose = <"به صورت دستی ترکیب و ثبت توضیحی خلاصه در مورد یک بیمار ، از نظر ارائه دهنده خدمات درمانی">
+			use = <"برای ثبت توضیح ، نظری خلاصه در مورد سلامت بیمار استفاده می شود.این خلاصه ساختار بندی نشده ممکن است شامل شناسایی مسایل بهداشتی ، مراقبت های بهداشتی ارایه شده همراه با تفسیر ، درک بیمار ، توانایی ارتباط با بیمار در مورد برخی جنبه های ذهنی و... در مورد تجربیات وسفرهای بیمار .معمولا این خلاصه به رویدادهای خاص سلامت نظیر مشاوره های خاص یا پذیرش بیمارستانی مربوط می شود اما ممکن است همچنین برای خلاصه نمودن تجربیات بیمار در طی دوره های زمانی مختلف استفاده شود
+در عمل،خلاصه بالینی مشاهده .... است که متمم مدارک ساختارمند بالینی کنونی خواهد بود که بیان اطلاعات دقیق ، ذهنی یا تفسیر را امکان پذیر می کند در غیر اینصورت از طریق داده های ساختار یافته به تنهایی امکان پذیر نیست و تعادل و چهارجوچوبی برای ثبت پرونده الکترونیک سلامت ارایه می کنند
+برای مثال خلاصه  بالینی می تواند بین خلاصه کوتاه پذیرش بیمارستانی بیمار به عنوان یکی از اجزا جامع و برگه ساختار مند خلاصه ترخیص ارتباط برقرار کند            ">
+			keywords = <"خلاصه", "نتیجه", "رئوس مطالب", "خلاصه رئوس مطالب", "چکیده", "ارزیابی", "خلاصه", "خلاصه انتقادی یا تحلیلی", "توضیحات", "یادداشت">
+			misuse = <"برای ثبت اطلاعات سلامت خاص و ساختار مند استفاده نمی شود. برای مثال اطلاعات جزیی درباره مشکلات ، تشخیصها و نتایج تست باید با استفاده از الگو ساز خاص ومربوطه .....و نتایج آزمایشگاهی یا رادیولوژی در ....ثبت شود. خلاصه بالینی ممکن است شامل برخی نتایج عددی حیاتی و انتخاب شده  از  جزییات ساختار مند باشد زمانی که برای تکمیل خلاصه مهم باشدامااین الگو ساز محل اولیه ثبت این موارد نیست
+واژه \"خلاصه بالینی \"کاهی به اسناد پیچیده و جامع اشاره می کند نظیر خلاصه ترخیص یا گزارش. در ... اسناد باید به عنوان توده ای از الگوسازهای محدود شده ارایه شود ، الگوی خلاصه ترخیص یا  الگوی گزارش شامل تعدادی از الگوسازهای جداگانه می باشد که الگوساز خلاصه بالینی یکی از این الگوسازها می باشد
+  ">
+		>
+		["ar-sy"] = <
+			language = <[ISO_639-1::ar-sy]>
+			purpose = <"لتسجيل ملخص برواية تم توليفها يدويا عن مريض من وجهة نظر مقدم الرعاية الصحية ">
+			use = <"لتسجيل رؤية ملخصة بتوليف رواية عن صحة المريض. هذا الملخص غير المركب قد يتضمن قضايا صحية مُعَرَّفة, تم تقديمها بواسطة مقدم الخدمة الصحية, مع إرفاق تفسير, و تفَهُّم المريض, و يُمَكِّن من توصيل بعض من الجوانب البسيطة غير موضوعية من خبرة و رحلة المريض.
+و غالبا ما يكون هذا الملخص ذي احتمال عالي أن يكون متعلقا بواقعة صحية, مثل استشارة معينة أو إدخال إلى المستشفى, و لكن قد يستخدم في تلخيص الخبرة الصحية للمريض خلال فترات زمنية متعددة.
+في الممارسة المعتادة, يعتبر المختصر السريري هو ملاحظة عامة تُكَمِّل السجل السريري المركب, و تسمح بالتعبير عن المعلومات الرقيقة غير الموضوعية التفسيرية عن المريض, و التي قد لا تكون واضحة إذا استخدم البيانات المركبة وحدها, بما يزوِّد اتزانا و سياقا للسجل الطبي الإلكتروني.
+مثل, قد يقوم المختصر السريري بتوصيل ملخص موجز عن إدخال المريض إلى المستشفى كجزء من وثيقة شاملة و مركبة حول ملخص الخروج.">
+			keywords = <"ملخص", "استنتاج", "إطار", "دقيق", "مستخلص", "تقييم", "مختصر", "نوبة إضافية", "تعليق", "ملحوظة">
+			misuse = <"لا يستخدم لتسجيل المعلومات الصحية المحددة و المركبة. مثلا, ينبغي تسجيل المعلومات التفصيلية حول المشكلات, التشخيصات, و نتائج الاختبارات باستخدام النماذج المخصصة ذات الصلة مثل (تقييم. مشكلة) و (تقييم. مشكلة - تشخيص) و نتائج اختبارات المعمل و التصوير الإشعاعي في نماذج الملاحظات.
+قد يوصل المختصر السريري بعض النتائج الرقمية من هذه التفاصيل إذا كان ذلك هاما لاكتمال المختصر, و لكن لا يعتبر الموضع الأولي لتسجيل هذه النتائج.
+
+قد يشير اللفظ (المختصر السريري) أحيانا إلى وثائق مركبة و شاملة, مثل ملخص الخروج أو تقرير ما.
+و ينبغي التعبير عن هذه الوثائق في نماذج مقيدة, و التي هي قالب ملخص الخروج و قالب التقرير, وسط مجموعة من النماذج يعتبر المختصر السريري واحدا منها.">
+		>
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			purpose = <"Die manuelle Herstellung und Aufnahme einer Zusammenfassung einer Patientengeschichte, aus der Sicht eines Gesundheitsdienstleisters.">
+			use = <"Benutzung für die Aufnahme einer geschichtlichen, zusammenfassenden Ansicht des Gesundheitszustandes des Patienten. Diese unstrukturierte Zusammenfassung kann identifizierte Gesundheitsprobleme, erbrachte Gesundheitsdienstleistungen, dazugehörige Interpretationen und Verständnis des Patienten enthalten sowie die Mitteilung mancher der subjektiverern, weicheren Aspekte über die Erfahrung und Geschichte aus Sicht des Patienten ermöglichen. Typischerweise hängt diese Zusammenfassung mit einem bestimmten Gesundheitsereignis zusammen, z. B. einem bestimmten Arztbesuch oder einer spezifischen Krankenhausaufnahme, kann jedoch auch benutzt werden um das Erlebnis des Patienten über verschiedene Zeitperioden zusammenzufassen.
+In Wirklichkeit ist Clinical Synopsis eine Meta-Beobachtung, die die bestehende strukturierte klinische Akte ergänzt, um subtile, subjektive oder interpretative Informationen über den Patienten ausdrücken zu können, die sonst alleine durch strukturierte Daten möglicherweise nicht deutlich werden; dies soll eine balancierte, kontextspezifische elektronische Patientenakte unterstützen.
+Beispielsweise kann eine Clinical Synopsis eine kurze Zusammenfassung der Aufnahme eines Patienten als eine Komponente eines umfassenden und strukturierten Epikrise-Dokuments übermitteln.">
+			keywords = <"Zusammenfassung", "Schlussfolgerung", "Kurzdarstellung", "Abriss", "Abstract", "Beurteilung", "Synopsis", "Epikrise", "Anmerkung", "Bemerkung">
+			misuse = <"Nicht zu benutzen um genaue und strukturierte Informationen aufzunehmen. Beispielsweise sollten detaillierte Informationen über Probleme, Diagnosen und Testergebnisse durch die entsprechend relevanten Archetypen EVALUATION.problem, EVALUATION.problem-diagnosis und OBSERVATION-Archetypen für Labpr- oder radiologische Ergebnisse aufgenommen werden. Die Clinical Synopsis darf manche kritische bzw. ausgewählte numerische Ergebnisse aus diesen strukturierten Details überbringen, wenn diese als wichtig für die Vollständigkeit der Synopsis beurteilt werden; sie ist jedoch NICHT die primäre Stelle zur Aufnahme solcher Informationen.
+Der Begriff \"Klinische Synopsis\" kann sich manchmal auf komplexe und umfangreiche Dokumente beziehen, z. B. eine Epikrise (Discharge Summary) oder ein Bericht (Report). In openEHR sollten diese Dokumente als Aggregationen eingeschränkter Archetypen dargestellt werden (sprich openEHR \"templates\"), d. h. eine Epikrise- oder Bericht-Vorlage, die aus mehreren einzelnen Archetypen besteht, wovon der Clinical Synopsis-Archetyp einer sein könnte.
+">
+		>
+		["es-ar"] = <
+			language = <[ISO_639-1::es-ar]>
+			purpose = <"Para sintetizar manualmente y registrar en forma narrativa un sumario acerca de un paciente, desde la perspectiva de un profesional del cuidado de la salud.">
+			use = <"Usado para registrar en forma narrativa, una vista resumida del estado de salud del paciente. Este sumario no estructurado, puede incluir problemas/condiciones de salud identificados, cuidados de la salud provistos, interpretaciones clínicas asociadas y el entendimiento del paciente acerca de su condición clínica. Esta síntesis puede permitir la comunicación acerca de aspectos más sutiles y subjetivos en relación con la experiencia del paciente. Mas comúnmente este sumario estará probablemente relacionado con eventos de salud específicos tales como consultas médicas concretas o internaciones, pero puede también ser usado para sumarizar la experiencia del paciente en relación con su salud, en diferentes periodos de tiempo.
+En la práctica, la Sinopsis Clínica es una meta-observación que complementará el registro clínico estructurado existente, permitiendo la expresión de información sutil, subjetiva o interpretativa acerca del paciente, que podría no ser obvia a través de solamente analizar los datos estructurados, proveyendo de esta forma balance y contexto al registro clínico.
+Por ejemplo, una Sinopsis Clínica puede comunicar un sumario sucinto de una internación del paciente, como un componente dentro de un documento de Epicrisis completo y estructurado.">
+			keywords = <"sumario", "conclusión", "visión global", "resumen", "extracto", "evaluación", "sinopsis", "epicrisis", "comentario", "nota">
+			misuse = <"No debe usarse para registrar información de salud estructurada y específica. Por ejemplo, información detallada relacionada con Problemas, Diagnósticos y Resultados de Estudios debería ser registrada usando los arquetipos específicos y relevantes EVALUATION.problem, EVALUATION.problem-diagnosis y resultados de laboratorio o imágenes en OBSERVATIONs. La Sinopsis Clínica puede expresar algunos resultados numéricos seleccionados críticos (presentes en secciones estructuradas específicas), cuando sean juzgados importantes para la completitud de la Sinopsis pero NO es el sitio primario de registro para esta información.
+El término “Sinopsis Clínica” puede referirse a veces a documentos complejos y detallados tales como Epicrisis o Reportes. En openEHR, estos documentos deberían ser representados como agregaciones de arquetipos restringidos. Por ejemplo, una plantilla de Epicrisis o de Reporte deberían estar compuestos por un grupo de arquetipos (entre los que se encontraría la Sinopsis Clínica).">
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			purpose = <"Para sintetizar manualmente e gravar um sumário narrativo sobre um paciente, a partir da perspectiva de um profissional de saúde.">
+			use = <"*Use to record a narrative, summary view of the patient's health.  This unstructured summary may include identified health issues; health care provided; associated interpretation; patient understanding; and enable communication about some of the softer, more subjective aspects of the patient’s experience and journey. Most commonly this summary is likely to be related to a specific health event such as a specific consultation or hospital admission, but may also be used to summarise the patient's health experience over varying time periods.
+In practice, Clinical Synopsis is a meta observation that will complement the existing structured clinical record, allowing for expression of subtle, subjective or interpretive information about the patient that might not otherwise be obvious through structured data alone, providing balance and context to the EHR record.
+For example, a Clinical Synopsis can communicate a succinct summary of the patient's hospital admission as one component of a comprehensive and structured Discharge Summary document.(en)">
+			keywords = <"sumário", "conclusão", "esboço", "resumo", "abstrato", "avaliação", "sinopse", "epícrise", "comentário", "anotações">
+			misuse = <"*Not to be used to record specific and structured health information. For example, detailed information about Problems, Diagnoses, and Test Results should be recorded using the specific relevant archetypes EVALUATION.problem, EVALUATION.problem-diagnosis, and laboratory or radiology results in OBSERVATIONs. The Clinical Synopsis may convey some critical and selected numerical results from these structured details when judged important for completeness of the Synopsis but is NOT the primary recording site for them.
+The term “Clinical Synopsis” can sometimes refer to complex and comprehensive documents, such as a Discharge Summary or a Report. In openEHR these documents should be represented as aggregations of constrained archetypes, that is, a Discharge Summary template or a Report template, comprising a number of separate archetypes, of which this Clinical Synopsis archetype may be one.(en)">
+		>
+		["zh-cn"] = <
+			language = <[ISO_639-1::zh-cn]>
+			purpose = <"从医疗保健服务提供着的角度，手工综合并记录关于患者的叙述型摘要。">
+			use = <"用于记录关于患者健康状况的叙述型摘要。这种非结构化摘要可以包括所确定的健康事项、所提供的医疗保健服务、相关联的解释和患者的理解，并且便于表达关于患者体验和经历的某些较为委婉和较为主观的方面。最为常见的情况就是，这种摘要很可能与特定的健康事件相关，如某次特定的会诊咨询或收治入院（住院），但也可以用于总结概括患者在不同时间段内的健康历程。临床提要是一种元观察（meta observation，超级观察），将对已有的结构化临床记录起到补充作用，允许表达关于患者的微妙的、主观的或解释性的信息，而仅仅借助于结构化数据，此类信息可能并非显而易见，从而为EHR记录提供了平衡和背景。例如，临床提要可以作为综合性的结构化出院摘要（出院小结、出院记录）文档的一个组成部分，传达对于患者住院情况的简要概括。">
+			keywords = <"摘要", "小结", "概要", "概况", "概略", "结论", "总结", "梗概", "大纲", "提要", "要点", "评估", "评价", "总览", "评论", "病案讨论", "病情分析", "备注", "注释", "记录", "笔记">
+			misuse = <"并非旨在用于记录具体的结构化健康信息。例如，对于有关问题、诊断和检验项目结果的详细信息，应当分别采用具体相关的原始型来加以记录，比如，分别采用评价类之中的问题（EVALUATION.problem）, 评价类之中的诊断（EVALUATION.problem-diagnosis）和观察类（OBSERVATION）之中实验室或放射医学结果。当判断认为此类结构化细节信息之中的某些至关重要的和精选的数值型结果对于当前提要的完整性具有重要作用的时候，临床提要可以传达此类结果，但这里并不是此类信息的原始记录位置。有时，“临床提要（Clinical Synopsis）”可能指的是复杂的综合性文档，如出院摘要（出院小结、出院记录）或报告。在openEHR之中，应当将此类文档表达为若干经过约束的原始型的聚合体，也就是说，出院摘要模板或报告模板是由许多不同的原始型构成，而临床提要原始型则可能只是后面所说的这些原始型之一。">
+		>
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To manually synthesise and record a narrative summary about a patient, from the perspective of a healthcare provider.">
+			use = <"Use to record a narrative, summary view of the patient's health.  This unstructured summary may include identified health issues; health care provided; associated interpretation; patient understanding; and enable communication about some of the softer, more subjective aspects of the patient’s experience and journey. Most commonly this summary is likely to be related to a specific health event such as a specific consultation or hospital admission, but may also be used to summarise the patient's health experience over varying time periods.
+In practice, Clinical Synopsis is a meta observation that will complement the existing structured clinical record, allowing for expression of subtle, subjective or interpretive information about the patient that might not otherwise be obvious through structured data alone, providing balance and context to the EHR record.
+For example, a Clinical Synopsis can communicate a succinct summary of the patient's hospital admission as one component of a comprehensive and structured Discharge Summary document.">
+			keywords = <"summary", "conclusion", "outline", "precis", "abstract", "assessment", "synopsis", "epicrisis", "comment", "note">
+			misuse = <"Not to be used to record specific and structured health information. For example, detailed information about Problems, Diagnoses, and Test Results should be recorded using the specific relevant archetypes EVALUATION.problem, EVALUATION.problem-diagnosis, and laboratory or radiology results in OBSERVATIONs. The Clinical Synopsis may convey some critical and selected numerical results from these structured details when judged important for completeness of the Synopsis but is NOT the primary recording site for them.
+The term “Clinical Synopsis” can sometimes refer to complex and comprehensive documents, such as a Discharge Summary or a Report. In openEHR these documents should be represented as aggregations of constrained archetypes, that is, a Discharge Summary template or a Report template, comprising a number of separate archetypes, of which this Clinical Synopsis archetype may be one.">
+		>
+	>
+	other_contributors = <"Koray Atalag, University of Auckland, New Zealand", "Marco Borges, P2D, Brazil", "Rong Chen, Cambio Healthcare Systems, Sweden", "Stephen Chu, NeHTA, Australia", "Tamsin Cockayne, Australia", "Paul Donaldson, Nursing Informatics Australia, Australia", "Shahla Foozonkhah, Ocean Informatics, Australia", "Sam Heard, Ocean Informatics, Australia", "Evelyn Hovenga, EJSH Consulting, Australia", "Eugene Igras, IRIS Systems, Inc., Canada", "Shinji Kobayashi, Ehime University, Japan", "Robert Legan, NEHTA, Australia", "Heather Leslie, Ocean Informatics, Australia", "Rikard Lovstrom, Swedish Medical Association, Sweden", "Rohan Martin, Ambulance Victoria, Australia", "Ian McNicoll, Ocean Informatics, United Kingdom", "Jeroen Meintjens, Medisch Centrum Alkmaar, Netherlands", "Arturo Romero, SESCAM, Spain">
+	other_details = <
+		["references"] = <"Clinical Synopsis (Data Specifications) Version 1.0 [Internet]. Sydney, Australia: National E-Health Transition Authority; 2007 Jun 29 [cited 2009 Oct 12]; Available at http://www.nehta.gov.au/DGL/Resources/Downloads/Clinical%20Synopsis%20v1.0.pdf">
+		["MD5-CAM-1.0.1"] = <"2D066E7C501C2DAEC625DEE2ECD81DF4">
+	>
+
+definition
+	EVALUATION[id1] matches {	-- Clinical Synopsis
+		data matches {
+			ITEM_TREE[id2] matches {
+				items cardinality matches {1..*; ordered} matches {
+					ELEMENT[id3] matches {	-- Synopsis
+						value matches {
+							DV_TEXT[id4]
+						}
+					}
+				}
+			}
+		}
+	}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Clinical Synopsis">
+				description = <"Narrative summary or overview about a patient, specifically from the perspective of a healthcare provider, and with or without associated interpretations.">
+			>
+			["id3"] = <
+				text = <"Synopsis">
+				description = <"The summary, assessment, conclusions or evaluation of the clinical findings.">
+			>
+		>
+		["fa"] = <
+			["id1"] = <
+				text = <"خلاصه بالینی">
+				description = <"خلاصه یا مروری تشریحی دربازه بیمار بویژه از نظز ارایه کننده مراقبت بهداشتی با یا بدون تفسیرهای مربوطه ">
+			>
+			["id3"] = <
+				text = <"خلاصه">
+				description = <"خلاصه ، ارزیابی ، نتیجه ، یا ارزشیابی یافته های بالینی">
+			>
+		>
+		["ar-sy"] = <
+			["id1"] = <
+				text = <"المختصر السريري">
+				description = <"ملخص بالرواية أو نظرة عامة عن المريض, خاصة من وجهة نظر مقدم الخدمة الصحية, مع إرفاق أو عدم إرفاق تفسيرات ">
+			>
+			["id3"] = <
+				text = <"المختصر">
+				description = <"الملخص, التقييم, الاستنتاجات أو التقييم للموجودات السريرية">
+			>
+		>
+		["de"] = <
+			["id1"] = <
+				text = <"Klinische Synopsis">
+				description = <"Zusammenfassung oder Übersicht einer Patientengeschichte, speziell aus der Sicht eines Gesundheitsdienstleisters, evtl. mit dazugehörigen Interpretationen.">
+			>
+			["id3"] = <
+				text = <"Synopsis">
+				description = <"Die Zusammenfassung, Beurteilung, Aussagen or Auswertung des klinischen Befunds.">
+			>
+		>
+		["es-ar"] = <
+			["id1"] = <
+				text = <"Sinopsis Clínica">
+				description = <"Sumario narrativo o visión global acerca de un paciente, específicamente desde la perspectiva de un profesional del cuidado de la salud, con o sin interpretaciones asociadas.">
+			>
+			["id3"] = <
+				text = <"Sinopsis">
+				description = <"El sumario, la impresión diagnóstica y las conclusiones sobre los hallazgos clínicos.">
+			>
+		>
+		["pt-br"] = <
+			["id1"] = <
+				text = <"Sinopse Clínica">
+				description = <"Resumo narrativo ou visão geral sobre um paciente, especificamente a partir da perspectiva de um profissional de saúde, e com ou sem interpretações associadas.">
+			>
+			["id3"] = <
+				text = <"Sinopse">
+				description = <" O sumário, a avaliação, conclusões ou avaliação dos achados clínicos.">
+			>
+		>
+		["zh-cn"] = <
+			["id1"] = <
+				text = <"临床提要">
+				description = <"从医疗保健服务提供着的角度，手工综合并记录关于患者的叙述型摘要或概述，且带有或没有相关联的解释。">
+			>
+			["id3"] = <
+				text = <"提要">
+				description = <"对于临床所见（临床发现）进行的概括、评估、总结或评价。">
+			>
+		>
+	>


### PR DESCRIPTION
### correctly flatten rules
There is no official spec how to flatten rules, but we do it anyway. When specializing:
- overwrite rules specialized with the same tag
- add rules to the bottom of the rules without the same tag

When combining with archetype roots:
- add the rules to the result, prefixing all tags and variables with a human readable tag and variable prefix to guarantee uniqueness. Prefix all paths with the correct path

### Many flattener fixes
- keep both id code and archetype ref for archetype roots
- allow specializing one constraint with multiple in a specialization
- correctly handle archetypeslot specialization, preserving order
- fix some errors

### serialization changes
- fix some typos in metadata serialization (UK vs US spelling)
- serialize and parse operational templates
- Serialize the structure under use_archetype

### parsing changes
- parse optional structure under use_archetype

### other fixes
- fix apath queries with RMQueryContext with dots in id code (id2.1)
