### PR TITLE
Set the differential attribute according to spec

### DIFF
--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -40,18 +40,25 @@ public class ADLListener extends AdlBaseListener {
     @Override
     public void enterArchetype(ArchetypeContext ctx) {
         rootArchetype = new AuthoredArchetype();
-        rootArchetype.setDifferential(true);
         archetype = rootArchetype;
         parseArchetypeHRID(ctx.ARCHETYPE_HRID());
     }
 
     @Override
+    public void exitArchetype(ArchetypeContext ctx) {
+        rootArchetype.setDifferential(archetype.getParentArchetypeId() != null);
+    }
+
+    @Override
     public void enterTemplate(TemplateContext ctx) {
         rootArchetype = new Template();
-        rootArchetype.setDifferential(false);
         archetype = rootArchetype;
         parseArchetypeHRID(ctx.ARCHETYPE_HRID());
+    }
 
+    @Override
+    public void exitTemplate(TemplateContext ctx) {
+        rootArchetype.setDifferential(archetype.getParentArchetypeId() != null);
     }
 
     @Override
@@ -74,7 +81,7 @@ public class ADLListener extends AdlBaseListener {
     @Override
     public void enterOperational_template(Operational_templateContext ctx) {
         rootArchetype = new OperationalTemplate();
-        rootArchetype.setDifferential(false);
+        rootArchetype.setDifferential(false);//operational templates are flat by definition
         archetype = rootArchetype;
         parseArchetypeHRID(ctx.ARCHETYPE_HRID());
     }

--- a/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -136,6 +136,7 @@ public class Flattener {
             TerminologyFlattener.filterLanguages((OperationalTemplate) result, removeLanguagesFromMetaData, languagesToKeep);
         }
         result.getDefinition().setArchetype(result);
+        result.setDifferential(false);//note this archetype as being flat
         return result;
     }
 

--- a/src/main/java/com/nedap/archie/rules/evaluation/Value.java
+++ b/src/main/java/com/nedap/archie/rules/evaluation/Value.java
@@ -56,4 +56,5 @@ public class Value<Type> {
     public static Value createNull(List<String> paths) {
         return new Value(null, paths);
     }
+
 }

--- a/src/test/java/com/nedap/archie/flattener/FlattenerTest.java
+++ b/src/test/java/com/nedap/archie/flattener/FlattenerTest.java
@@ -184,8 +184,9 @@ public class FlattenerTest {
 
     @Test
     public void height() throws Exception {
+        assertTrue(heightTemplate.isDifferential());
         Archetype flattened = flattener.flatten(heightTemplate);
-
+        assertFalse(flattened.isDifferential());
         CObject object = (CObject) new APathQuery("/content[openEHR-EHR-OBSERVATION.ovl-length-height-001.v1.0.0]").find(flattened.getDefinition());
         assertNotNull(object);
         assertNotNull(flattened.getTerm(object, "nl"));


### PR DESCRIPTION
differential param on archetype was not set correctly. It should be set to differential=false on archetypes without a parent id, or flattened archetypes. True in other situations.