### PR TITLE
Fix archetype root redefinition, add some error messages

### DIFF
--- a/src/main/antlr/cadl.g4
+++ b/src/main/antlr/cadl.g4
@@ -30,7 +30,7 @@ c_non_primitive_object:
     | archetype_slot
     ;
 
-c_archetype_root: SYM_USE_ARCHETYPE type_id '[' ID_CODE SYM_COMMA archetype_ref ']' c_occurrences? ( SYM_MATCHES '{' c_attribute_def+ '}' )? ;
+c_archetype_root: SYM_USE_ARCHETYPE type_id '[' ID_CODE (SYM_COMMA archetype_ref)? ']' c_occurrences? ( SYM_MATCHES '{' c_attribute_def+ '}' )? ;
 
 c_complex_object_proxy: SYM_USE_NODE type_id '[' ID_CODE ']' c_occurrences? adl_path ;
 

--- a/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
+++ b/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
@@ -200,7 +200,9 @@ public class CComplexObjectParser extends BaseTreeWalker {
 
         root.setRmTypeName(archetypeRootContext.type_id().getText());
         root.setNodeId(archetypeRootContext.ID_CODE().getText());
-        root.setArchetypeRef(archetypeRootContext.archetype_ref().getText());
+        if(archetypeRootContext.archetype_ref() != null) {
+            root.setArchetypeRef(archetypeRootContext.archetype_ref().getText());
+        }
 
         root.setOccurrences(this.parseMultiplicityInterval(archetypeRootContext.c_occurrences()));
         for (C_attribute_defContext attributeContext : archetypeRootContext.c_attribute_def()) {


### PR DESCRIPTION
- implement C_ARCHETYPE_ROOT redefinition
- allow ```use_archetype[idx] occurrences matches {0}``` in the grammar - it works in the adl workbench
- create an operational template for the most specialized archetype only, not when creating the flat parents. It would introduce errors in some cases.
- because the operational template now is created in the last separate step, change C_COMPLEX_OBJECT_PROXY replacement to work from nearest archetype root constraint instead of just archetype definition.