### PR TITLE
Wrap errors for setting fields with useful information

### DIFF
--- a/src/main/java/com/nedap/archie/creation/RMObjectCreator.java
+++ b/src/main/java/com/nedap/archie/creation/RMObjectCreator.java
@@ -9,6 +9,7 @@ import com.nedap.archie.rminfo.RMAttributeInfo;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -106,8 +107,13 @@ public class RMObjectCreator {
     }
 
     private void setField(Object object, RMAttributeInfo field, Object value) throws InvocationTargetException, IllegalAccessException {
-        field.getSetMethod().invoke(object, value);
-
+        Method setMethod = field.getSetMethod();
+        try {
+            setMethod.invoke(object, value);
+        } catch (Exception e) {
+            Class<?> valueType = value == null ? null : value.getClass();
+            throw new RuntimeException("Error setting value '" + value + "' of type '" + valueType + "' using method '" + setMethod + "'", e);
+        }
     }
 
     public void addElementToList(Object object, RMAttributeInfo attributeInfo, Object element) {


### PR DESCRIPTION
Currently it is very hard to determine why `java.lang.IllegalArgumentException: argument type mismatch` errors are thrown when inserting new compositions. This PR makes it easier to determine why these errors are thrown.